### PR TITLE
Jur/meet/1.x/#7 html modeling content/fix insertion nesting

### DIFF
--- a/src/aiassistservice.ts
+++ b/src/aiassistservice.ts
@@ -310,6 +310,7 @@ export default class AiAssistService {
 	 * @param parent - The parent element whose content will be cleared.
 	 */
 	private clearParentContent( parent: Element ): void {
+		console.log( 'clearing parent content', parent );
 		this.editor.model.change( writer => {
 			while ( parent.childCount > 0 ) {
 				const child = parent.getChild( 0 );


### PR DESCRIPTION
refactor(HtmlParser): use model.insertContent and fix streaming 

Use model.insertContent for all insertions, fix streaming to keep text in one element, implement isCompleteHtmlChunk, resolve type errors. Improves alignment with CKEditor 5 practices and fixes nested elements and cursor issues.