### PR TITLE
Added cancel generation button at top-left for POC of abort controller

### DIFF
--- a/src/aiassistcommand.ts
+++ b/src/aiassistcommand.ts
@@ -3,6 +3,7 @@ import type AiAssistService from './aiassistservice.js';
 import type { Editor } from 'ckeditor5';
 export default class AiAssistCommand extends Command {
 	private aiAssistService: AiAssistService;
+	private abortController?: AbortController;
 
 	/**
 	 * Creates an instance of the AiAssistCommand.
@@ -13,6 +14,12 @@ export default class AiAssistCommand extends Command {
 	constructor( editor: Editor, aiAssistService: AiAssistService ) {
 		super( editor );
 		this.aiAssistService = aiAssistService;
+
+		// Listen for the custom event from Command A
+		this.listenTo( editor, 'CancelGeneration', ( evt, data ) => {
+			console.log( this.abortController );
+			this.aiAssistService.cancelResponseGeneration();
+		} );
 	}
 
 	/**
@@ -31,6 +38,7 @@ export default class AiAssistCommand extends Command {
 	 * @param options - An optional parameter for additional execution options.
 	 */
 	public override async execute(): Promise<void> {
+		this.abortController = new AbortController();
 		await this.aiAssistService.handleSlashCommand();
 	}
 }

--- a/src/aiassistservice.ts
+++ b/src/aiassistservice.ts
@@ -23,6 +23,7 @@ export default class AiAssistService {
 	private buffer = '';
 	private openTags: Array<string> = [];
 	private isInlineInsertion: boolean = false;
+	private abortController?: AbortController;
 
 	/**
 	 * Initializes the AiAssistService with the provided editor and configuration settings.
@@ -129,9 +130,10 @@ export default class AiAssistService {
 		console.log( 'Starting fetchAndProcessGptResponse' );
 		const editor = this.editor;
 		const t = editor.t;
-		const controller = new AbortController();
+		this.abortController = new AbortController();
+		console.log( this.abortController );
 		const timeoutId = setTimeout(
-			() => controller.abort(),
+			() => this.abortController?.abort(),
 			this.timeOutDuration
 		);
 
@@ -156,7 +158,7 @@ export default class AiAssistService {
 					stop: this.stopSequences,
 					stream: true
 				} ),
-				signal: controller.signal
+				signal: this.abortController.signal
 			} );
 
 			clearTimeout( timeoutId );
@@ -390,5 +392,9 @@ export default class AiAssistService {
 			console.error( error );
 			return null;
 		}
+	}
+
+	public async cancelResponseGeneration(): Promise<void> {
+		console.log( this.abortController?.signal );
 	}
 }

--- a/src/aiassistui.ts
+++ b/src/aiassistui.ts
@@ -3,6 +3,7 @@ import { ButtonView, createDropdown, SplitButtonView } from 'ckeditor5/src/ui.js
 import aiAssistIcon from '../theme/icons/ai-assist.svg';
 import { aiAssistContext } from './aiassistcontext.js';
 import { SUPPORTED_LANGUAGES } from './const.js';
+import { env } from 'ckeditor5/src/utils.js';
 
 export default class AiAssistUI extends Plugin {
 	public PLACEHOLDER_TEXT_ID = 'slash-placeholder';
@@ -109,6 +110,40 @@ export default class AiAssistUI extends Plugin {
 			} );
 			return view;
 		} );
+
+		editor.ui.componentFactory.add( 'customPositionButton', locale => {
+			const buttonView = new ButtonView( locale );
+			const cmd = '\u2318'; // Unicode for the Command key (⌘)
+			const ctrl = '\u2303'; // Unicode for the Control key (⌃)
+			const keystroke = env.isMac ? `${ cmd }\u232B` : `${ ctrl }\u232B`;
+			buttonView.set( {
+				withKeystroke: true,
+				label: `${ keystroke } Cancel Generation`,
+				labelStyle: 'font-weight: 100; font-size:0.85em; color: gray',
+				withText: true, // Show button text
+				class: 'ck-cancel-request'
+			} );
+
+			// Execute action when button is clicked
+			buttonView.on( 'execute', () => {
+				// this.editor.fire(`CancelGeneration`);
+			} );
+
+			// Return the button view
+			return buttonView;
+		} );
+
+		const buttonContainer = document.createElement( 'div' );
+		buttonContainer.id = 'customButtonContainer';
+		buttonContainer.style.position = 'fixed';
+		buttonContainer.style.top = '50px'; // Change top and left to your desired position
+		buttonContainer.style.left = '20px';
+
+		const button = editor.ui.componentFactory.create( 'customPositionButton' );
+		button.render(); // Render the button
+
+		buttonContainer.appendChild( button.element! );
+		document.body.appendChild( buttonContainer );
 	}
 
 	/**
@@ -339,6 +374,18 @@ export default class AiAssistUI extends Plugin {
 	 * Hides the error tooltip element from the document.
 	 */
 	private hideGptErrorToolTip(): void {
+		const tooltipElement = document.getElementById(
+			this.GPT_RESPONSE_ERROR_ID
+		);
+		if ( tooltipElement ) {
+			tooltipElement.classList.remove( 'show-response-error' );
+		}
+	}
+
+	/**
+	 * Hides the error tooltip element from the document.
+	 */
+	private add(): void {
 		const tooltipElement = document.getElementById(
 			this.GPT_RESPONSE_ERROR_ID
 		);

--- a/theme/style.css
+++ b/theme/style.css
@@ -122,3 +122,17 @@
 		text-shadow: none;
 	}
 }
+
+.ck-cancel-request {
+	border: 1px solid hsla(0, 0%, 86%, 1) !important;
+	padding: 5px 10px !important;
+	min-height: 1.7em !important;
+	max-height: 1.7em !important;
+	border-radius: 0.25em !important;
+	cursor: pointer !important;
+	background-color: hsla(0, 0%, 97%, 1) !important;
+}
+
+.ck-cancel-request-label {
+	font-weight: 200 !important;
+}


### PR DESCRIPTION
Link: #11 

This PR introduces the AbortController mechanism to enable cancellation of requests partway through execution. However, we've encountered an issue where the updated values within the listener for the command are not being recognized. Specifically, the listener does not reflect the latest state, impacting the command's ability to respond to the AbortController signal effectively.

We are seeking suggestions or reviews on:

Ensuring that the listener accurately receives and reflects the updated values needed for the command to function as expected.
Any potential alternative approaches for handling mid-execution request cancellations, especially within our current setup.
