### PR TITLE
feat(ai-assist): improve cancel generation button implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The AiAgent plugin can be configured through the EditorConfig interface. Here ar
 | `promptSettings.filters` | `Array<string>` | Contains any filtering logic or constraints to refine the AI's output. (optional) |
 | `debugMode` | `boolean` | Enables debug mode, which logs detailed information about prompts and API requests to the console. Default is false. (optional) |
 | `streamContent` | `boolean` | Enables stream mode, which stream the response of request. Default is true (optional) |
+| `moderation.key` | `string` | API key for content moderation service. Required if moderation is enabled. Used to filter inappropriate or unsafe content. (optional) |
+| `moderation.enable` | `boolean` | Enables content moderation for AI responses. When true, responses are checked against moderation rules before being displayed. Default is false. (optional) |
 
 ## Usage Examples
 

--- a/src/aiagentservice.d.ts
+++ b/src/aiagentservice.d.ts
@@ -16,6 +16,7 @@ export default class AiAgentService {
     private buffer;
     private openTags;
     private isInlineInsertion;
+    private abortGeneration;
     /**
      * Initializes the AiAgentService with the provided editor and configuration settings.
      *
@@ -37,6 +38,31 @@ export default class AiAgentService {
      * @returns A promise that resolves when the response has been processed.
      */
     private fetchAndProcessGptResponse;
+    /**
+     * Creates and configures a cancel generation button with keyboard shortcut support.
+     *
+     * @param blockID - Unique identifier for the AI generation block
+     * @param controller - AbortController to cancel the ongoing AI generation
+     * @private
+     */
+    private cancelGenerationButton;
+    /**
+     * Handles cleanup after AI generation is completed or cancelled.
+     * Removes the cancel button from the UI and cleans up the temporary AI tag from editor content.
+     *
+     * @param blockID - Unique identifier for the AI generation block to be cleaned up
+     * @private
+     */
+    private processCompleted;
+    /**
+     * Updates the content of an AI-generated block in the editor.
+     *
+     * @param newHtml - The new HTML content to insert
+     * @param blockID - The unique identifier of the AI block to update
+     * @param insertParent - Whether to insert at parent level or child level
+     * @returns Promise that resolves when the update is complete
+     * @private
+     */
     private updateContent;
     /**
      * Processes the provided content and inserts it into the specified parent element.

--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -4,6 +4,8 @@ import type { AiModel, MarkdownContent } from './type-identifiers.js';
 import { aiAgentContext } from './aiagentcontext.js';
 import { PromptHelper } from './util/prompt.js';
 import { HtmlParser } from './util/htmlparser.js';
+import { ButtonView } from 'ckeditor5/src/ui.js';
+import { env } from 'ckeditor5/src/utils.js';
 
 export default class AiAgentService {
 	private editor: Editor;
@@ -23,6 +25,7 @@ export default class AiAgentService {
 	private buffer = '';
 	private openTags: Array<string> = [];
 	private isInlineInsertion: boolean = false;
+	private abortGeneration: boolean = false;
 
 	/**
 	 * Initializes the AiAgentService with the provided editor and configuration settings.
@@ -172,9 +175,11 @@ export default class AiAgentService {
 			const decoder = new TextDecoder( 'utf-8' );
 
 			this.clearParentContent( parent );
-			this.editor.enableReadOnlyMode( this.aiAgentFeatureLockId );
+			// this.editor.enableReadOnlyMode( this.aiAgentFeatureLockId );
 
 			let insertParent = true;
+
+			this.cancelGenerationButton( blockID, controller );
 
 			editor.model.change( writer => {
 				const position = editor.model.document.selection.getLastPosition();
@@ -244,11 +249,12 @@ export default class AiAgentService {
 				}
 			}
 
-			const editorData = editor.getData();
-			let editorContent = editorData.replace( `<ai-tag id="${ blockID }">`, '' );
-			editorContent = editorContent.replace( '</ai-tag>', '' );
-			editor.setData( editorContent );
+			this.processCompleted( blockID );
 		} catch ( error: any ) {
+			if ( this.abortGeneration ) {
+				return;
+			}
+
 			console.error( 'Error in fetchAndProcessGptResponse:', error );
 			const errorIdentifier =
 				( error?.message || '' ).trim() || ( error?.name || '' ).trim();
@@ -289,6 +295,93 @@ export default class AiAgentService {
 		}
 	}
 
+	/**
+     * Creates and configures a cancel generation button with keyboard shortcut support.
+     *
+     * @param blockID - Unique identifier for the AI generation block
+     * @param controller - AbortController to cancel the ongoing AI generation
+     * @private
+     */
+	private cancelGenerationButton( blockID: string, controller: AbortController ) {
+		const editor = this.editor;
+		const t = editor.t;
+
+		const view = new ButtonView();
+		let label = t( 'Cancel Generation' );
+
+		if ( env.isMac ) {
+			label = t( '\u2318 + \u232B Cancel Generation' );
+		}
+
+		if ( env.isWindows ) {
+			label = t( 'Ctrl + \u232B Cancel Generation' );
+		}
+
+		view.set( {
+			label,
+			withText: true,
+			class: 'ck-cancel-request-button'
+		} );
+
+		view.on( 'execute', () => {
+			this.abortGeneration = true;
+			controller.abort();
+			this.processCompleted( blockID );
+		} );
+
+		view.render();
+
+		editor.keystrokes.set( 'Ctrl+Backspace', ( keyEvtData, cancel ) => {
+			if ( keyEvtData.ctrlKey || keyEvtData.metaKey ) {
+				this.abortGeneration = true;
+				controller.abort();
+				this.processCompleted( blockID );
+			}
+			cancel();
+		} );
+
+		if ( editor.ui.view.element && view.element ) {
+			const panelContent = editor.ui.view.element.querySelector( '.ck-sticky-panel__content .ck-toolbar__items' );
+			if ( panelContent ) {
+				panelContent.append( view.element );
+			}
+		}
+
+		setTimeout( () => view.set( { class: 'ck-cancel-request-button visible' } ), 2000 );
+	}
+
+	/**
+	 * Handles cleanup after AI generation is completed or cancelled.
+	 * Removes the cancel button from the UI and cleans up the temporary AI tag from editor content.
+	 *
+	 * @param blockID - Unique identifier for the AI generation block to be cleaned up
+	 * @private
+	 */
+	private processCompleted( blockID: string ) {
+		const editor = this.editor;
+
+		if ( editor.ui.view.element ) {
+			const cancelButton = editor.ui.view.element.querySelector( '.ck-cancel-request-button' );
+			if ( cancelButton ) {
+				cancelButton.remove();
+			}
+		}
+
+		const editorData = editor.getData();
+		let editorContent = editorData.replace( `<ai-tag id="${ blockID }">`, '' );
+		editorContent = editorContent.replace( '</ai-tag>', '' );
+		editor.setData( editorContent );
+	}
+
+	/**
+	 * Updates the content of an AI-generated block in the editor.
+	 *
+	 * @param newHtml - The new HTML content to insert
+	 * @param blockID - The unique identifier of the AI block to update
+	 * @param insertParent - Whether to insert at parent level or child level
+	 * @returns Promise that resolves when the update is complete
+	 * @private
+	 */
 	private async updateContent( newHtml: string, blockID: string, insertParent: boolean ): Promise<void> {
 		const editor = this.editor;
 		editor.model.change( writer => {

--- a/src/aiagentui.js
+++ b/src/aiagentui.js
@@ -5,6 +5,7 @@ import aiAgentIcon from '../theme/icons/ai-agent.svg';
 import { aiAgentContext } from './aiagentcontext.js';
 import { SUPPORTED_LANGUAGES } from './const.js';
 import { Widget, toWidget } from 'ckeditor5/src/widget.js';
+import { env } from 'ckeditor5/src/utils.js';
 export default class AiAgentUI extends Plugin {
     constructor() {
         super(...arguments);
@@ -122,6 +123,21 @@ export default class AiAgentUI extends Plugin {
         });
         editor.model.schema.extend('$block', { allowIn: 'ai-tag' });
         this.addCustomTagConversions();
+        let keystroke = '';
+        if (env.isMac) {
+            keystroke = 'Cmd + Backspace';
+        }
+        if (env.isWindows) {
+            keystroke = 'Ctrl + Backspace';
+        }
+        editor.accessibility.addKeystrokeInfos({
+            keystrokes: [
+                {
+                    label: t('Cancel AI Generation'),
+                    keystroke
+                }
+            ]
+        });
     }
     addCustomTagConversions() {
         const editor = this.editor;

--- a/src/aiagentui.ts
+++ b/src/aiagentui.ts
@@ -5,6 +5,7 @@ import aiAgentIcon from '../theme/icons/ai-agent.svg';
 import { aiAgentContext } from './aiagentcontext.js';
 import { SUPPORTED_LANGUAGES } from './const.js';
 import { Widget, toWidget } from 'ckeditor5/src/widget.js';
+import { env } from 'ckeditor5/src/utils.js';
 
 export default class AiAgentUI extends Plugin {
 	public PLACEHOLDER_TEXT_ID = 'slash-placeholder';
@@ -136,6 +137,22 @@ export default class AiAgentUI extends Plugin {
 		editor.model.schema.extend( '$block', { allowIn: 'ai-tag' } );
 
 		this.addCustomTagConversions();
+		let keystroke = '';
+		if ( env.isMac ) {
+			keystroke = 'Cmd + Backspace';
+		}
+
+		if ( env.isWindows ) {
+			keystroke = 'Ctrl + Backspace';
+		}
+		editor.accessibility.addKeystrokeInfos( {
+			keystrokes: [
+				{
+					label: t( 'Cancel AI Generation' ),
+					keystroke
+				}
+			]
+		} );
 	}
 
 	private addCustomTagConversions(): void {

--- a/theme/style.css
+++ b/theme/style.css
@@ -122,3 +122,49 @@
 		text-shadow: none;
 	}
 }
+
+.ck.ck-button.ck-cancel-request-button {
+	cursor: pointer;
+	left: 0;
+	margin: 0 auto;
+	padding: 0.3125rem 0.625rem;
+	position: absolute;
+	right: 0;
+	top: 2.8125rem;
+	width: fit-content;
+	box-shadow: 0px 2px 6px var(--ck-color-shadow-drop);
+	z-index: 1;
+	transform: scale(1.1);
+	background: var(--ck-color-input-background);
+	opacity: 0;
+	transition: opacity 300ms ease-in;
+	pointer-events: none;
+}
+.ck.ck-button.ck-cancel-request-button:hover {
+	background: var(--ck-color-button-default-hover-background);
+}
+
+.ck.ck-button.ck-cancel-request-button.visible {
+	opacity: 1;
+	pointer-events: auto;
+	/* Enable interactions */
+}
+
+.ck.ck-toolbar>.ck-toolbar__items>.ck.ck-cancel-request-button:last-child {
+	margin-right: auto;
+}
+
+.ck.ck-button.ck-cancel-request-button .ck-button__label {
+	font-weight: 100;
+	font-size: 1em;
+	color: var(--ck-color-text);
+	line-height: 1;
+}
+
+/* Disable animation for users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+	#cancel-button {
+		transition: none;
+		/* Disable all transitions */
+	}
+}


### PR DESCRIPTION
- Add proper TypeScript typing for button configuration
- Implement Mac/Windows keyboard shortcut detection
- Add AbortController integration for canceling AI generations
- Improve button styling and accessibility
- Add keyboard shortcut support (Ctrl/Cmd + Backspace)
- Clean up UI elements after generation completes

BREAKING CHANGE: The cancel generation command now requires an AbortController to be passed for proper cleanup.

Closes #11