### PR TITLE
fix: Regression in contentScope Feature After Merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       # Upload test results (optional)
       - name: Archive test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: test-results/

--- a/src/util/prompt.ts
+++ b/src/util/prompt.ts
@@ -76,7 +76,13 @@ export class PromptHelper {
 		if ( this.contentScope ) {
 			const activeEditorElement = this.editor.editing.view.getDomRoot();
 			const targetElement = activeEditorElement?.closest( this.contentScope );
-			context = targetElement?.innerHTML ?? '';
+			const ckContents = targetElement?.querySelectorAll( '.ck-content' );
+			if ( ckContents?.length ) {
+				context = '';
+				Array.from( ckContents ).map( item => {
+					context += context ? `\n${ item.innerHTML }` : item.innerHTML;
+				} );
+			}
 		}
 
 		const matchIndex = context.indexOf( splitText );


### PR DESCRIPTION
- Loops through all `.ck-content` elements.
- Concatenates their innerHTML with newline separation, ensuring the full context is captured correctly.

Closes #93