### PR TITLE
fix: Cancel Button Not Removing After API Streaming Completion

### DIFF
--- a/src/aiagentservice.js
+++ b/src/aiagentservice.js
@@ -434,8 +434,9 @@ export default class AiAgentService {
      */
     processCompleted(blockID) {
         const editor = this.editor;
-        if (editor.ui.view.element) {
-            const cancelButton = editor.ui.view.element.querySelector('.ck-cancel-request-button');
+        const toolbarElement = editor.ui.view.toolbar.element;
+        if (toolbarElement) {
+            const cancelButton = toolbarElement.querySelector('.ck-cancel-request-button');
             if (cancelButton) {
                 cancelButton.remove();
             }

--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -516,9 +516,9 @@ export default class AiAgentService {
 	 */
 	private processCompleted( blockID: string ) {
 		const editor = this.editor;
-
-		if ( editor.ui.view.element ) {
-			const cancelButton = editor.ui.view.element.querySelector( '.ck-cancel-request-button' );
+		const toolbarElement = ( editor.ui.view as any ).toolbar.element;
+		if ( toolbarElement ) {
+			const cancelButton = toolbarElement.querySelector( '.ck-cancel-request-button' );
 			if ( cancelButton ) {
 				cancelButton.remove();
 			}


### PR DESCRIPTION
Simplified the logic for removing the cancel button by directly referencing editor.ui.view.element

Closes #104