### PR TITLE
refactor!: flatten moderation config structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ The AiAgent plugin can be configured through the EditorConfig interface. Here ar
 | `debugMode` | `boolean?` | `false` | Enables debug mode for detailed logging |
 | `streamContent` | `boolean?` | `true` | Enables streaming mode for responses |
 | `showErrorDuration` | `number?` | `5000` | Duration in milliseconds for error message display |
-| `moderation.enable` | `boolean?` | `false` | Enables content moderation for AI responses |
-| `moderation.key` | `string?` | - | API key for content moderation service |
-| `moderation.disableFlags` | `Array<ModerationFlagsTypes>?` | - | Array of moderation flags to disable |
+| `moderationEnable` | `boolean?` | `false` | Enables content moderation for AI responses |
+| `moderationKey` | `string?` | - | API key for content moderation service |
+| `moderationDisableFlags` | `Array<ModerationFlagsTypes>?` | - | Array of moderation flags to disable |
 | `commandsDropdown` | `Array<{ title: string; items: Array<{ title: string; command: string; }>; }>?` | Default menu with tone adjustment, content enhancement, and fix/improve commands | Specifies the commands available in the dropdown menu |
 | `contentScope` | `string?` | - | CSS selector that extends context gathering to include content from other CKEditor 5 instances found within the first matching ancestor element |
 

--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -52,9 +52,9 @@ export default class AiAgentService {
 		this.retryAttempts = config.retryAttempts!;
 		this.stopSequences = config.stopSequences!;
 		this.streamContent = config.streamContent ?? true;
-		this.moderationKey = config.moderation?.key ?? '';
-		this.moderationEnable = config.moderation?.enable ?? false;
-		this.disableFlags = config.moderation?.disableFlags ?? [];
+		this.moderationKey = config.moderationKey ?? '';
+		this.moderationEnable = config.moderationEnable ?? false;
+		this.disableFlags = config.moderationDisableFlags ?? [];
 	}
 
 	/**

--- a/src/augmentation.ts
+++ b/src/augmentation.ts
@@ -48,11 +48,12 @@ declare module '@ckeditor/ckeditor5-core' {
             streamContent?: boolean;
             debugMode?: boolean;
             showErrorDuration?: number;
-            moderation?: {
-                key: string;
-                enable: boolean;
-                disableFlags?: Array<ModerationFlagsTypes>;
-            };
+
+            // Moderation Settings
+            moderationKey?: string;
+            moderationEnable?: boolean;
+            moderationDisableFlags?: Array<ModerationFlagsTypes>;
+
             commandsDropdown?: Array<{
                 title: string;
                 items: Array<{

--- a/src/type-identifiers.ts
+++ b/src/type-identifiers.ts
@@ -42,6 +42,9 @@ export interface AiAgentConfig {
     promptSettings?: PromptSettings;
     streamContent?: boolean;
     debugMode?: boolean;
+    moderationKey?: string;
+    moderationEnable?: boolean;
+    moderationDisableFlags?: Array<ModerationFlagsTypes>;
 }
 
 export interface MarkdownContent {


### PR DESCRIPTION
BREAKING CHANGE: Moderation configuration structure has been flattened from nested object to top-level keys for better consistency and maintainability.

- Changed moderation.key to moderationKey
- Changed moderation.enable to moderationEnable
- Changed moderation.disableFlags to moderationDisableFlags

mapping config structures was being a major pain in managing the Drupal module and its different global/text editor configs.
flatten all the things.