### PR TITLE
refactor: Refactoring AI Agent Content Streaming Rate Limiting CK5 Mo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The AiAgent plugin can be configured through the EditorConfig interface. Here ar
 | `moderationDisableFlags` | `Array<ModerationFlagsTypes>?` | - | Array of moderation flags to disable |
 | `commandsDropdown` | `Array<{ title: string; items: Array<{ title: string; command: string; }>; }>?` | Default menu with tone adjustment, content enhancement, and fix/improve commands | Specifies the commands available in the dropdown menu |
 | `contentScope` | `string?` | - | CSS selector that extends context gathering to include content from other CKEditor 5 instances found within the first matching ancestor element |
+| `writesPerSecond` | `WritesPerSecond?` | 10 | Specifies the maximum number of writes the AI Agent can perform per second. This setting helps control the rate of content generation, allowing for smoother performance and better resource management during high-load scenarios. |
 
 ### Prompt Components
 The plugin uses various prompt components to guide AI response generation. You can customize these through the `promptSettings` configuration.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxpr/ckeditor5-ai-agent",
-  "version": "1.0.0-beta29",
+  "version": "1.0.0-beta30",
   "description": "A plugin for CKEditor 5.",
   "keywords": [
     "ckeditor",
@@ -12,7 +12,7 @@
     "ckeditor5-package-generator"
   ],
   "type": "module",
-  "main": "src/index.ts",
+  "main": "src/index.js",
   "exports": {
     ".": {
       "types": "./src/index.d.ts",

--- a/sample/ckeditor.ts
+++ b/sample/ckeditor.ts
@@ -100,6 +100,9 @@ ClassicEditor
 		},
 		aiAgent: {
 			apiKey: 'YOUR_API_KEY',
+			engine: 'kavya',
+			model: 'gemini/gemini-2.0-flash-lite-preview-02-05',
+			endpointUrl: 'http://0.0.0.0:8091/v1/chat/completions',
 			debugMode: true,
 			commandsDropdown: [
 				{
@@ -190,6 +193,9 @@ const inlineEditorConfig = {
 	},
 	aiAgent: {
 		apiKey: 'YOUR_API_KEY',
+		engine: 'kavya',
+		model: 'gemini/gemini-2.0-flash-001',
+		endpointUrl: 'https://kavya.dxpr.com/v1/chat/completions',
 		contentScope: '.page-builder-container',
 		debugMode: true
 	},

--- a/src/aiagent.ts
+++ b/src/aiagent.ts
@@ -75,8 +75,9 @@ export default class AiAgent extends Plugin {
 
 		// 2. Check engine-specific requirements
 		if ( AI_CUSTOM_ENGINE.includes( config.engine as any ) ) {
+			// TODO: Chooses models to support in production
 			if ( !AI_CUSTOM_MODEL.includes( config.model as any ) ) {
-				throw new Error( `AiAgent: model is not allowed for ${ config.engine }` );
+			// 	throw new Error( `AiAgent: model is not allowed for ${ config.engine }` );
 			}
 
 			if ( !config.endpointUrl ) {

--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -44,7 +44,7 @@ export default class AiAgentService {
 	private writesPerSecond: number;
 
 	private readonly STORAGE_PREFIX = 'ck5-ai-agent';
-	private readonly FILTERED_STRINGS = /```html|```/g;
+	private readonly FILTERED_STRINGS = /```html|```|html\n/g;
 
 	/**
 	 * Initializes the AiAgentService with the provided editor and configuration settings.

--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -40,7 +40,8 @@ export default class AiAgentService {
 	private moderationKey: string;
 	private moderationEnable: boolean;
 	private disableFlags: Array<ModerationFlagsTypes> = [];
-	private s: any;
+	private stream: any;
+	private writesPerSecond: number;
 
 	private readonly STORAGE_PREFIX = 'ck5-ai-agent';
 	private readonly FILTERED_STRINGS = /```html|```/g;
@@ -69,6 +70,7 @@ export default class AiAgentService {
 		this.moderationKey = config.moderationKey ?? '';
 		this.moderationEnable = config.moderationEnable ?? false;
 		this.disableFlags = config.moderationDisableFlags ?? [];
+		this.writesPerSecond = config.writesPerSecond ?? 10;
 	}
 
 	/**
@@ -309,7 +311,7 @@ export default class AiAgentService {
 
 				if ( this.streamContent ) {
 					// Streaming path
-					const stream = llm.generate( this.aiModel, messages, completionOpts );
+					const stream = this.generate( llm, this.aiModel, messages, completionOpts );
 					await this.handleStreamingResponse( stream, blockID, parent, command, controller, llm, resetTimeout );
 				} else {
 					// Non-streaming path
@@ -454,38 +456,48 @@ export default class AiAgentService {
 	): Promise<void> {
 		let isFirstChunk = true;
 		let contentBuffer = '';
+		const updateInterval = 1000 / this.writesPerSecond; // Calculate interval in ms
 
-		for await ( const c of stream ) {
-			if ( isFirstChunk ) {
-				aiAgentContext.hideLoader();
-				this.cancelGenerationButton( blockID, controller, llm, stream );
-				this.undoRedoHandler();
-				this.insertAiTag( blockID );
-				this.clearParentContent( parent, command );
-				isFirstChunk = false;
+		const updateContent = async () => {
+			if ( contentBuffer ) {
+				await this.updateContent( contentBuffer, blockID );
 			}
+		};
 
-			this.s = c;
-			const chunk = c as any;
+		const updateContentTimer = setInterval( updateContent, updateInterval );
+		try {
+			for await ( const c of stream ) {
+				if ( isFirstChunk ) {
+					aiAgentContext.hideLoader();
+					this.cancelGenerationButton( blockID, controller, llm );
+					this.undoRedoHandler();
+					this.insertAiTag( blockID );
+					this.clearParentContent( parent, command );
+					isFirstChunk = false;
+				}
+				const chunk = c as any;
 
-			if ( chunk.type === 'status' ) {
-				await this.animatedStatusMessages( chunk.text, blockID );
-			}
+				if ( chunk.type === 'status' ) {
+					await this.animatedStatusMessages( chunk.text, blockID );
+				}
 
-			if ( chunk.type === 'content' && chunk.text?.trim() ) {
 				// Filter out markdown code blocks and normalize content
 				const filteredText = chunk.text
 					.replace( this.FILTERED_STRINGS, '' )
 					.trim();
 
-				if ( filteredText ) {
+				if ( chunk.type === 'content' ) {
 					contentBuffer += filteredText;
-					await this.updateContent( contentBuffer, blockID );
 				}
-			}
 
-			// Reset timeout when data is received
-			resetTimeout();
+				// Reset timeout when data is received
+				resetTimeout();
+			}
+		} finally {
+			clearInterval( updateContentTimer );
+			await updateContent();
+			this.processCompleted( blockID );
+			contentBuffer = '';
 		}
 		this.processCompleted( blockID );
 	}
@@ -518,7 +530,7 @@ export default class AiAgentService {
      * @param controller - AbortController to cancel the ongoing AI generation
      * @private
      */
-	private cancelGenerationButton( blockID: string, controller: AbortController, llm: LlmEngine | undefined, stream: any ) {
+	private cancelGenerationButton( blockID: string, controller: AbortController, llm: LlmEngine | undefined ) {
 		const editor = this.editor;
 		const t = editor.t;
 
@@ -542,7 +554,7 @@ export default class AiAgentService {
 		view.on( 'execute', () => {
 			this.abortGeneration = true;
 			if ( llm ) {
-				llm.stop( llm );
+				llm.stop( this.stream );
 			} else {
 				controller.abort();
 			}
@@ -555,7 +567,7 @@ export default class AiAgentService {
 			if ( keyEvtData.ctrlKey || keyEvtData.metaKey ) {
 				this.abortGeneration = true;
 				if ( llm ) {
-					llm.stop( stream );
+					llm.stop( this.stream );
 				} else {
 					controller.abort();
 				}
@@ -571,7 +583,6 @@ export default class AiAgentService {
 				panelContent.append( view.element );
 			}
 		}
-
 		setTimeout( () => view.set( { class: 'ck-cancel-request-button visible' } ), 2000 );
 	}
 
@@ -1022,5 +1033,35 @@ export default class AiAgentService {
 				}
 			}
 		} );
+	}
+
+	/**
+	 * Generates a stream of messages from the specified language model (LLM) based on the provided input thread.
+	 * This method handles the streaming of responses, yielding each message as it is received.
+	 *
+	 * @param llm - The language model instance used for generating responses.
+	 * @param model - The identifier of the model to be used for generation.
+	 * @param thread - An array of messages that form the context for the generation.
+	 * @param opts - Options for the LLM completion, such as max tokens and temperature.
+	 * @returns An async generator that yields messages from the LLM as they are received.
+	 *
+	 * @throws Will throw an error if the streaming process fails or if the model is invalid.
+	 */
+	private async* generate( llm: any, model: string, thread: Array<Message>, opts: LlmCompletionOpts ): any {
+		this.stream = await llm.stream( model, thread, opts );
+		while ( this.stream != null ) {
+			let stream2 = null;
+			for await ( const chunk of this.stream ) {
+				const stream3 = llm.nativeChunkToLlmChunk( chunk );
+				for await ( const msg of stream3 ) {
+					if ( msg.type === 'stream' ) {
+						stream2 = msg.stream;
+					} else {
+						yield msg;
+					}
+				}
+			}
+			this.stream = stream2;
+		}
 	}
 }

--- a/src/type-identifiers.ts
+++ b/src/type-identifiers.ts
@@ -24,6 +24,8 @@ export interface ModelTokenLimits {
     maxInputContextTokens: number;
 }
 
+type WritesPerSecond = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+
 export interface AiAgentConfig {
     engine?: AiEngine;
     model?: string;
@@ -67,6 +69,7 @@ export interface AiAgentConfig {
         }>;
     }>;
     contentScope?: string;
+    writesPerSecond?: WritesPerSecond;
 }
 
 export interface MarkdownContent {


### PR DESCRIPTION
…del Updates

- Implemented a mechanism to update the CKEditor content based on a configurable frequency, allowing for smoother and more responsive content generation.
- Introduced a timer that triggers content updates at specified intervals, enhancing the user experience during AI response streaming.
- Added `writesPerSecond` configuration to allow users to set the desired number of updates per second (e.g., 5 times per second).
- Replaced the `generate` function from the multi-llm-ts library with a custom implementation to support streaming responses.
- The new `generate` function allows for aborting the stream, addressing limitations in the multi-llm-ts library that did not support stream termination.

Closes #115