### PR TITLE
Jur/1.x/add html support to content scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxpr/ckeditor5-ai-agent",
-  "version": "1.0.0-beta33",
+  "version": "1.0.0-beta34",
   "description": "A plugin for CKEditor 5.",
   "keywords": [
     "ckeditor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxpr/ckeditor5-ai-agent",
-  "version": "1.0.0-beta32",
+  "version": "1.0.0-beta33",
   "description": "A plugin for CKEditor 5.",
   "keywords": [
     "ckeditor",

--- a/src/types/html-cleanup.ts
+++ b/src/types/html-cleanup.ts
@@ -1,0 +1,111 @@
+import type { Editor } from 'ckeditor5/src/core.js';
+
+export interface AttributeConfig {
+
+	/**
+	 * Whether to preserve all values for this attribute
+	 */
+	preserveAll?: boolean;
+
+	/**
+	 * List of allowed selectors. Can include:
+	 * - Simple class names: '.btn'
+	 * - Complex selectors: '[class^="col-"]'
+	 * - Multiple patterns: '[class*="col-"],[class*="cols-"]'
+	 */
+	allowedSelectors?: Array<string>;
+}
+
+export interface HtmlCleanupConfig {
+
+	/**
+	 * Map of attribute names to their configuration
+	 */
+	attributes: Record<string, AttributeConfig>;
+
+	/**
+	 * CSS selectors for elements that should be removed before cleanup
+	 */
+	blacklist: Array<string>;
+}
+
+export interface HtmlCleanupOptions {
+
+	/**
+	 * Configuration for HTML cleanup
+	 */
+	config: HtmlCleanupConfig;
+
+	/**
+	 * CKEditor instance for extensibility
+	 */
+	editor: Editor;
+}
+
+/**
+ * Default configuration that can be extended
+ */
+export const DEFAULT_HTML_CLEANUP_CONFIG: HtmlCleanupConfig = {
+	attributes: {
+		'id': {
+			preserveAll: true
+		},
+		'alt': {
+			preserveAll: true
+		},
+		'title': {
+			preserveAll: true
+		},
+		'href': {
+			preserveAll: true // Preserves link destinations
+		},
+		'type': {
+			preserveAll: true // Preserves input types for better form understanding
+		},
+		'name': {
+			preserveAll: true // Preserves form field names
+		},
+		'placeholder': {
+			preserveAll: true
+		},
+		'class': {
+			allowedSelectors: [
+				// Layout classes
+				'[class*="col-"]',
+				'.col',
+				'[class*="row"]',
+				'[class*="container"]',
+
+				// UI elements
+				'.btn',
+				'.button',
+				'.card',
+				'.panel',
+				'.list',
+				'.grid',
+
+				// Media
+				'[class*="image"]',
+				'[class*="video"]',
+
+				// Navigation
+				'.nav',
+				'.header',
+				'.footer',
+				'.sidebar'
+			]
+		}
+	},
+	blacklist: [
+		// UI Controls - only essential ones
+		'.controls',
+		'.dxpr-builder-ui',
+
+		// Resource tags - only essential ones
+		'style',
+		'script',
+		'link[rel="stylesheet"]',
+		'meta',
+		'noscript'
+	]
+};

--- a/src/util/html-cleanup.ts
+++ b/src/util/html-cleanup.ts
@@ -1,0 +1,172 @@
+import type { Editor } from 'ckeditor5/src/core.js';
+import { DEFAULT_HTML_CLEANUP_CONFIG, type HtmlCleanupConfig, type HtmlCleanupOptions } from '../types/html-cleanup.js';
+
+/**
+ * Service for cleaning up HTML content based on configurable rules
+ */
+export class HtmlCleanupService {
+	private config: HtmlCleanupConfig;
+	private editor: Editor;
+
+	constructor( options: HtmlCleanupOptions ) {
+		this.editor = options.editor;
+
+		// Merge default config with user config
+		const userConfig = this.editor.config.get( 'aiAgent.htmlCleanup' ) ?? {};
+		this.config = this.mergeConfigs( DEFAULT_HTML_CLEANUP_CONFIG, userConfig );
+	}
+
+	/**
+	 * Clean HTML content based on configuration
+	 *
+	 * @param html - HTML content to clean
+	 * @returns Cleaned HTML content
+	 */
+	public clean( html: string ): string {
+		if ( this.editor.config.get( 'aiAgent.debugMode' ) ) {
+			console.log( '[HTML Cleanup] Initial HTML:', html );
+		}
+
+		// Simple string replacement for inline-slash
+		const slashCommand = '<inline-slash class="ck-slash">/test</inline-slash>';
+		html = html.split( slashCommand ).join( '@@@cursor@@@' );
+
+		// Simple string replacement for cursor marker in span
+		const spanWrappedCursor = '<span class="ck-list-bogus-paragraph">@@@cursor@@@</span>';
+		html = html.split( spanWrappedCursor ).join( '@@@cursor@@@' );
+
+		if ( this.editor.config.get( 'aiAgent.debugMode' ) ) {
+			console.log( '[HTML Cleanup] After cursor cleanup:', html );
+		}
+
+		const parser = new DOMParser();
+		const doc = parser.parseFromString( html, 'text/html' );
+
+		// Remove blacklisted elements
+		this.removeBlacklistedElements( doc.body );
+
+		// Clean remaining elements
+		this.cleanNode( doc.body );
+
+		const result = doc.body.innerHTML;
+
+		if ( this.editor.config.get( 'aiAgent.debugMode' ) ) {
+			console.log( '[HTML Cleanup] Final result:', result );
+		}
+
+		return result;
+	}
+
+	/**
+	 * Remove elements matching blacklisted selectors
+	 *
+	 * @param node - Root node to process
+	 */
+	private removeBlacklistedElements( node: Element ): void {
+		// Process all blacklisted selectors
+		for ( const selector of this.config.blacklist ) {
+			const elements = node.querySelectorAll( selector );
+			elements.forEach( element => element.remove() );
+		}
+	}
+
+	/**
+	 * Recursively clean a DOM node and its children
+	 *
+	 * @param node - DOM node to clean
+	 */
+	private cleanNode( node: Element ): void {
+		// Process attributes on current node
+		if ( node.hasAttributes() ) {
+			const attributes = Array.from( node.attributes );
+			for ( const attr of attributes ) {
+				const attrConfig = this.config.attributes[ attr.name ];
+
+				if ( !attrConfig ) {
+					// Remove attributes not in config
+					node.removeAttribute( attr.name );
+					continue;
+				}
+
+				if ( attrConfig.preserveAll ) {
+					// Keep attribute as is
+					continue;
+				}
+
+				if ( attrConfig.allowedSelectors && attr.name === 'class' ) {
+					// For class attributes, check each class against selectors
+					const classNames = attr.value.split( ' ' );
+					const allowedClasses = classNames.filter( className => {
+						// Create a temporary element to test selectors against
+						const testElement = document.createElement( 'div' );
+						testElement.className = className;
+
+						// Check if the class matches any of our selectors
+						return attrConfig.allowedSelectors!.some( selector => {
+							try {
+								return testElement.matches( selector ) ||
+									// Handle direct class name comparison for backward compatibility
+									selector.replace( /^\./, '' ) === className;
+							} catch ( e ) {
+								// If selector is invalid, try as a RegExp pattern
+								try {
+									const pattern = new RegExp( selector.replace( /\./g, '\\.' ) );
+									return pattern.test( className );
+								} catch {
+									return false;
+								}
+							}
+						} );
+					} );
+
+					if ( allowedClasses.length ) {
+						node.setAttribute( attr.name, allowedClasses.join( ' ' ) );
+					} else {
+						node.removeAttribute( attr.name );
+					}
+				}
+			}
+		}
+
+		// Process child nodes
+		const children = Array.from( node.children );
+		for ( const child of children ) {
+			this.cleanNode( child );
+		}
+	}
+
+	/**
+	 * Deep merge two configurations
+	 *
+	 * @param defaultConfig - Default configuration
+	 * @param userConfig - User provided configuration
+	 * @returns Merged configuration
+	 */
+	private mergeConfigs( defaultConfig: HtmlCleanupConfig, userConfig: Partial<HtmlCleanupConfig> ): HtmlCleanupConfig {
+		const merged: HtmlCleanupConfig = {
+			attributes: { ...defaultConfig.attributes },
+			blacklist: [ ...defaultConfig.blacklist ]
+		};
+
+		if ( userConfig.attributes ) {
+			for ( const [ key, value ] of Object.entries( userConfig.attributes ) ) {
+				if ( merged.attributes[ key ] ) {
+					// Merge attribute configs
+					merged.attributes[ key ] = {
+						...merged.attributes[ key ],
+						...value
+					};
+				} else {
+					// Add new attribute config
+					merged.attributes[ key ] = value;
+				}
+			}
+		}
+
+		if ( userConfig.blacklist ) {
+			merged.blacklist = [ ...merged.blacklist, ...userConfig.blacklist ];
+		}
+
+		return merged;
+	}
+}

--- a/src/util/prompt.ts
+++ b/src/util/prompt.ts
@@ -6,6 +6,8 @@ import { countTokens, trimLLMContentByTokens } from './token-utils.js';
 import { fetchMultipleUrls } from './url-utils.js';
 import { getDefaultRules } from './default-rules.js';
 import { getAllowedHtmlTags } from './html-utils.js';
+import { DEFAULT_HTML_CLEANUP_CONFIG } from '../types/html-cleanup.js';
+import { HtmlCleanupService } from './html-cleanup.js';
 
 // Default token limits if no specific match is found
 const DEFAULT_MAX_INPUT_TOKENS = 1000000;
@@ -77,6 +79,7 @@ export class PromptHelper {
 	private debugMode: boolean;
 	private editorContextRatio: number;
 	private contentScope: string;
+	private htmlCleanup: HtmlCleanupService;
 
 	constructor( editor: Editor, options: { editorContextRatio?: number } = {} ) {
 		this.editor = editor;
@@ -101,6 +104,8 @@ export class PromptHelper {
 				finalContextSize: this.contextSize
 			} );
 		}
+
+		this.htmlCleanup = new HtmlCleanupService( { editor, config: DEFAULT_HTML_CLEANUP_CONFIG } );
 	}
 
 	public getSystemPrompt( isInlineResponse: boolean = false ): string {
@@ -150,25 +155,33 @@ export class PromptHelper {
 		let contentBeforePrompt = '';
 		let contentAfterPrompt = '';
 		const splitText = promptContainerText ?? prompt;
-		const view = this.editor?.editing?.view?.domRoots?.get( 'main' );
-		let context = view?.innerHTML ?? '';
+		let context = '';
 
 		if ( this.debugMode ) {
 			console.group( 'HTML Content Debug' );
-			console.log( '1. Initial HTML context:', context );
+			console.log( '1. Initial context:', context );
 		}
 
+		// First get raw HTML content
 		if ( this.contentScope ) {
 			const activeEditorElement = this.editor.editing.view.getDomRoot();
 			const targetElement = activeEditorElement?.closest( this.contentScope );
-			const ckContents = targetElement?.querySelectorAll( '.ck-content' );
-			if ( ckContents?.length ) {
-				context = '';
-				Array.from( ckContents ).map( item => {
-					context += context ? `\n${ item.innerHTML }` : item.innerHTML;
-				} );
+			if ( targetElement ) {
+				// Clean the HTML before any processing
+				context = this.htmlCleanup.clean( targetElement.innerHTML );
+
 				if ( this.debugMode ) {
-					console.log( '2. Content scope HTML:', context );
+					console.log( '2. Content scope HTML (cleaned):', context );
+					console.log( '3. Character count before splitting:', context.length );
+				}
+
+				// Ensure we don't exceed limits from the start
+				const maxChars = Math.floor( this.contextSize * this.editorContextRatio ) * 4;
+				if ( context.length > maxChars ) {
+					context = context.substring( 0, maxChars );
+					if ( this.debugMode ) {
+						console.log( '3a. Content trimmed to length limit:', context );
+					}
 				}
 			}
 		}
@@ -181,9 +194,11 @@ export class PromptHelper {
 		const contextParts = [ beforeNewline, afterNewline ];
 
 		if ( this.debugMode ) {
-			console.log( '3. Split context parts:', {
+			console.log( '4. Split context parts:', {
 				beforeNewline,
-				afterNewline
+				afterNewline,
+				beforeLength: beforeNewline.length,
+				afterLength: afterNewline.length
 			} );
 		}
 
@@ -220,9 +235,12 @@ export class PromptHelper {
 		}
 
 		if ( this.debugMode ) {
-			console.log( '4. After extractEditorContent:', {
+			console.log( '5. After extractEditorContent:', {
 				contentBeforePrompt,
-				contentAfterPrompt
+				contentAfterPrompt,
+				beforeLength: contentBeforePrompt.length,
+				afterLength: contentAfterPrompt.length,
+				totalLength: contentBeforePrompt.length + contentAfterPrompt.length
 			} );
 		}
 
@@ -234,7 +252,8 @@ export class PromptHelper {
 		const trimmedContext = `${ contentBeforePrompt }\n${ contentAfterPrompt }`;
 
 		if ( this.debugMode ) {
-			console.log( '5. Final trimmed context:', trimmedContext );
+			console.log( '6. Final trimmed context:', trimmedContext );
+			console.log( 'Final character count:', trimmedContext.length );
 			console.groupEnd();
 		}
 

--- a/src/util/prompt.ts
+++ b/src/util/prompt.ts
@@ -151,13 +151,11 @@ export class PromptHelper {
 		let contentAfterPrompt = '';
 		const splitText = promptContainerText ?? prompt;
 		const view = this.editor?.editing?.view?.domRoots?.get( 'main' );
-		let context = view?.innerText ?? '';
+		let context = view?.innerHTML ?? '';
 
 		if ( this.debugMode ) {
-			console.log( '[Context]', {
-				contextSize: this.contextSize,
-				editorContextRatio: this.editorContextRatio
-			} );
+			console.group( 'HTML Content Debug' );
+			console.log( '1. Initial HTML context:', context );
 		}
 
 		if ( this.contentScope ) {
@@ -169,6 +167,9 @@ export class PromptHelper {
 				Array.from( ckContents ).map( item => {
 					context += context ? `\n${ item.innerHTML }` : item.innerHTML;
 				} );
+				if ( this.debugMode ) {
+					console.log( '2. Content scope HTML:', context );
+				}
 			}
 		}
 
@@ -179,15 +180,14 @@ export class PromptHelper {
 		const afterNewline = context.substring( firstNewlineIndex + 1 );
 		const contextParts = [ beforeNewline, afterNewline ];
 
-		const allocatedEditorContextToken = Math.floor( this.contextSize * this.editorContextRatio );
-
 		if ( this.debugMode ) {
-			console.log( '[Context Size]', {
-				allocatedTokens: allocatedEditorContextToken,
-				beforeLength: contextParts[ 0 ].length,
-				afterLength: contextParts[ 1 ].length
+			console.log( '3. Split context parts:', {
+				beforeNewline,
+				afterNewline
 			} );
 		}
+
+		const allocatedEditorContextToken = Math.floor( this.contextSize * this.editorContextRatio );
 
 		if ( contextParts.length > 1 ) {
 			if ( contextParts[ 0 ].length < contextParts[ 1 ].length ) {
@@ -219,12 +219,25 @@ export class PromptHelper {
 			}
 		}
 
+		if ( this.debugMode ) {
+			console.log( '4. After extractEditorContent:', {
+				contentBeforePrompt,
+				contentAfterPrompt
+			} );
+		}
+
 		// Combine the trimmed context with the cursor placeholder
 		const escapedPrompt = prompt.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' ); // Escapes special characters
 		contentBeforePrompt = contentBeforePrompt.trim()
 			.replace( new RegExp( escapedPrompt.slice( 1 ) ), '@@@cursor@@@' )
 			.replace( '/@@@cursor@@@', '@@@cursor@@@' ); // Remove forward slash if present
 		const trimmedContext = `${ contentBeforePrompt }\n${ contentAfterPrompt }`;
+
+		if ( this.debugMode ) {
+			console.log( '5. Final trimmed context:', trimmedContext );
+			console.groupEnd();
+		}
+
 		return trimmedContext.trim();
 	}
 
@@ -238,7 +251,7 @@ export class PromptHelper {
 		if ( this.debugMode ) {
 			console.group( 'formatFinalPrompt Debug' );
 			console.log( 'Request:', request );
-			console.log( 'Context:', context );
+			console.log( 'Context received:', context );
 			console.log( 'MarkDownContents:', markDownContents );
 			console.log( 'IsEditorEmpty:', isEditorEmpty );
 		}
@@ -254,13 +267,17 @@ export class PromptHelper {
 		// Context Section
 		if ( context?.length && !selectedContent ) {
 			corpus.push( '\n<CONTEXT>' );
+			corpus.push( '<![CDATA[' );
 			corpus.push( context );
+			corpus.push( ']]>' );
 			corpus.push( '</CONTEXT>' );
 		}
 
 		if ( selectedContent ) {
 			corpus.push( '<SELECTED_CONTENT>' );
+			corpus.push( '<![CDATA[' );
 			corpus.push( selectedContent );
+			corpus.push( ']]>' );
 			corpus.push( '</SELECTED_CONTENT>' );
 		}
 

--- a/src/util/prompt.ts
+++ b/src/util/prompt.ts
@@ -286,17 +286,13 @@ export class PromptHelper {
 		// Context Section
 		if ( context?.length && !selectedContent ) {
 			corpus.push( '\n<CONTEXT>' );
-			corpus.push( '<![CDATA[' );
 			corpus.push( context );
-			corpus.push( ']]>' );
 			corpus.push( '</CONTEXT>' );
 		}
 
 		if ( selectedContent ) {
 			corpus.push( '<SELECTED_CONTENT>' );
-			corpus.push( '<![CDATA[' );
 			corpus.push( selectedContent );
-			corpus.push( ']]>' );
 			corpus.push( '</SELECTED_CONTENT>' );
 		}
 

--- a/src/util/prompt.ts
+++ b/src/util/prompt.ts
@@ -162,27 +162,33 @@ export class PromptHelper {
 			console.log( '1. Initial context:', context );
 		}
 
-		// First get raw HTML content
+		// Get raw HTML content based on configuration
 		if ( this.contentScope ) {
+			// Use contentScope if configured
 			const activeEditorElement = this.editor.editing.view.getDomRoot();
 			const targetElement = activeEditorElement?.closest( this.contentScope );
 			if ( targetElement ) {
-				// Clean the HTML before any processing
 				context = this.htmlCleanup.clean( targetElement.innerHTML );
+			}
+		} else {
+			// Otherwise get content directly from editor
+			const editorElement = this.editor.editing.view.getDomRoot();
+			if ( editorElement ) {
+				context = this.htmlCleanup.clean( editorElement.innerHTML );
+			}
+		}
 
-				if ( this.debugMode ) {
-					console.log( '2. Content scope HTML (cleaned):', context );
-					console.log( '3. Character count before splitting:', context.length );
-				}
+		if ( this.debugMode ) {
+			console.log( '2. Editor HTML (cleaned):', context );
+			console.log( '3. Character count before splitting:', context.length );
+		}
 
-				// Ensure we don't exceed limits from the start
-				const maxChars = Math.floor( this.contextSize * this.editorContextRatio ) * 4;
-				if ( context.length > maxChars ) {
-					context = context.substring( 0, maxChars );
-					if ( this.debugMode ) {
-						console.log( '3a. Content trimmed to length limit:', context );
-					}
-				}
+		// Ensure we don't exceed limits from the start
+		const maxChars = Math.floor( this.contextSize * this.editorContextRatio ) * 4;
+		if ( context.length > maxChars ) {
+			context = context.substring( 0, maxChars );
+			if ( this.debugMode ) {
+				console.log( '3a. Content trimmed to length limit:', context );
 			}
 		}
 

--- a/src/util/text-utils.ts
+++ b/src/util/text-utils.ts
@@ -57,6 +57,19 @@ export function extractEditorContent(
 	reverse: boolean = false,
 	editor: Editor
 ): string {
+	// Check if content contains HTML
+	if ( /<[^>]*>/g.test( contentAfterPrompt ) ) {
+		// For HTML content, preserve tags and just trim by length
+		if ( contentAfterPrompt.length <= contextSize ) {
+			return contentAfterPrompt;
+		}
+
+		return reverse ?
+			contentAfterPrompt.slice( -contextSize ) :
+			contentAfterPrompt.slice( 0, contextSize );
+	}
+
+	// For plain text, use existing sentence-based logic
 	let trimmedContent = '';
 	let charCount = 0;
 


### PR DESCRIPTION
Adds HTML cleanup service to sanitize content before AI processing to help AI understand its content in broader context, e.g. landing pages and forms. Handles inline-slash commands, cursor markers, and preserves essential HTML attributes while removing unwanted elements.