### PR TITLE
fix: Placeholder text only shows on focus in CKEditor 5

### DIFF
--- a/src/aiagentui.ts
+++ b/src/aiagentui.ts
@@ -116,12 +116,6 @@ export default class AiAgentUI extends Plugin {
 		const editor = this.editor;
 		const model = editor.model;
 
-		model.document.on( 'change:data', () => {
-			setTimeout( () => {
-				this.applyPlaceholderToCurrentLine();
-			}, 10 );
-		} );
-
 		model.document.selection.on( 'change:range', () => {
 			setTimeout( () => {
 				this.applyPlaceholderToCurrentLine();
@@ -142,6 +136,14 @@ export default class AiAgentUI extends Plugin {
 						writer.remove( item );
 					}
 				} );
+			}
+		} );
+
+		editor.editing.view.document.on( 'change:isFocused', ( evt, data, isFocused ) => {
+			if (isFocused) {
+				setTimeout( () => {
+					this.applyPlaceholderToCurrentLine();
+				}, 10 );
 			}
 		} );
 
@@ -237,7 +239,10 @@ export default class AiAgentUI extends Plugin {
 
 			const parentPanelContent = editor.ui.view.editable.element?.parentElement;
 			if ( parentPanelContent ) {
-				parentPanelContent.style.position = 'relative';
+				console.log(parentPanelContent.style.position);
+				if (parentPanelContent.style.position !== 'absolute'){
+					parentPanelContent.style.position = 'relative';
+				}
 			}
 
 			const panelContent = editor.ui.view.editable.element;

--- a/theme/style.css
+++ b/theme/style.css
@@ -3,7 +3,6 @@
 	position: absolute;
 	z-index: -1;
 	opacity: 0;
-	color: hsl(0, 0%, 50%);
 	transition-duration: 0.2s;
 	transition-property: opacity;
 	transition-timing-function: ease-in, ease-out;
@@ -17,7 +16,7 @@
 }
 
 .show-place-holder {
-	opacity: 1;
+	opacity: 0.75;
 	transition-duration: 1s;
 	z-index: 100;
 }


### PR DESCRIPTION
- Add focus event listener to show placeholder only when editor is focused
- Update placeholder CSS to use opacity-based styling (0.75)

Closes #140