### PR TITLE
feat(ai): add internal markdown fetching with fallback to external se…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dxpr/ckeditor5-ai-agent",
-  "version": "1.0.0-beta60",
+  "version": "1.0.0-beta64",
   "description": "AI Agent plugin for CKEditor 5 enabling content generation, modification, and enhancement.",
   "keywords": [
     "ckeditor",

--- a/src/util/url-utils.ts
+++ b/src/util/url-utils.ts
@@ -37,6 +37,91 @@ export async function fetchMultipleUrls(
 }
 
 /**
+ * Tries to fetch internal markdown from the website by appending .md to the URL
+ *
+ * @param cleanedUrl - The cleaned URL to try
+ * @returns Promise resolving to markdown content or null
+ */
+async function fetchInternalMarkdown( cleanedUrl: string ): Promise<string | null> {
+	try {
+		const markdownUrl = `${ cleanedUrl }.md`;
+		const response = await fetch( markdownUrl, {
+			method: 'GET',
+			headers: {
+				Accept: 'text/markdown, text/plain, */*'
+			}
+		} );
+
+		if ( !response.ok ) {
+			return null; // Not found or error, fallback to external service
+		}
+
+		const content = await response.text();
+
+		if ( !content.trim() ) {
+			return null; // Empty content, fallback to external service
+		}
+
+		return content.trim();
+	} catch ( error ) {
+		// Any error means fallback to external service
+		return null;
+	}
+}
+
+/**
+ * Fetches content using jina.ai reader service
+ *
+ * @param cleanedUrl - The cleaned URL to fetch
+ * @param originalUrl - The original URL for error reporting
+ * @param maxRetries - Maximum number of retry attempts (default: 3)
+ * @returns Promise resolving to content or null
+ */
+async function fetchWithJina(
+	cleanedUrl: string,
+	originalUrl: string,
+	maxRetries: number = 3
+): Promise<string | null> {
+	const requestURL = `https://r.jina.ai/${ cleanedUrl.trim() }`;
+
+	for ( let attempt = 0; attempt < maxRetries; attempt++ ) {
+		try {
+			const response = await fetch( requestURL.trim() );
+
+			if ( !response.ok ) {
+				throw new Error( `HTTP error! status: ${ response.status }` );
+			}
+
+			const content = await response.text();
+
+			if ( content.includes( 'Warning: Target URL returned error' ) ) {
+				throw new Error( `Target URL (${ originalUrl }) returned an error` );
+			}
+
+			if ( content.trim().length === 0 ) {
+				throw new Error( 'Empty content received' );
+			}
+
+			return content
+				.replace( /\(https?:\/\/[^\s]+\)/g, '' )
+				.replace( /^\s*$/gm, '' )
+				.trim();
+		} catch ( error: any ) {
+			if ( attempt === maxRetries - 1 ) {
+				console.error( `Failed to fetch content after ${ maxRetries } attempts: ${ originalUrl }`, error );
+				aiAgentContext.showError( `Failed to fetch content from ${ originalUrl }` );
+				return null;
+			} else {
+				// Exponential backoff
+				await new Promise( resolve => setTimeout( resolve, Math.pow( 2, attempt ) * 1000 ) );
+			}
+		}
+	}
+
+	return null;
+}
+
+/**
  * Fetches content from a URL with retry logic
  *
  * @param url - The URL to fetch from
@@ -56,42 +141,19 @@ async function fetchUrlWithRetry(
 		return result;
 	}
 
-	for ( let attempt = 0; attempt < maxRetries; attempt++ ) {
-		try {
-			const cleanedUrl = trimmedUrl.replace( /[^\x20-\x7E]/g, '' );
-			const requestURL = `https://r.jina.ai/${ cleanedUrl.trim() }`;
-			const response = await fetch( requestURL.trim() );
+	const cleanedUrl = trimmedUrl.replace( /[^\x20-\x7E]/g, '' );
 
-			if ( !response.ok ) {
-				throw new Error( `HTTP error! status: ${ response.status }` );
-			}
+	// First, try to fetch internal markdown
+	const internalContent = await fetchInternalMarkdown( cleanedUrl );
+	if ( internalContent ) {
+		result.content = internalContent;
+		return result;
+	}
 
-			const content = await response.text();
-
-			if ( content.includes( 'Warning: Target URL returned error' ) ) {
-				throw new Error( `Target URL (${ trimmedUrl }) returned an error` );
-			}
-
-			if ( content.trim().length === 0 ) {
-				throw new Error( 'Empty content received' );
-			}
-
-			result.content = content
-				.replace( /\(https?:\/\/[^\s]+\)/g, '' )
-				.replace( /^\s*$/gm, '' )
-				.trim();
-
-			return result;
-		} catch ( error: any ) {
-			if ( attempt === maxRetries - 1 ) {
-				result.error = error.message;
-				console.error( `Failed to fetch content after ${ maxRetries } attempts: ${ url }`, error );
-				aiAgentContext.showError( `Failed to fetch content from ${ url }` );
-			} else {
-				// Exponential backoff
-				await new Promise( resolve => setTimeout( resolve, Math.pow( 2, attempt ) * 1000 ) );
-			}
-		}
+	// Fallback to external service if internal markdown not available
+	const jinaContent = await fetchWithJina( cleanedUrl, trimmedUrl, maxRetries );
+	if ( jinaContent ) {
+		result.content = jinaContent;
 	}
 
 	return result;


### PR DESCRIPTION
…rvice

- Add fetchInternalMarkdown function to try {url}.md before external service
- Refactor fetchUrlWithRetry into separate focused functions for cleaner architecture
- Add fetchWithJina function to handle external AI service integration
- Maintain graceful fallback chain: internal markdown -> external service -> null
- Support proper content negotiation with Accept headers for markdown content
- Improve error handling and separation of concerns in AI content fetching

This enables faster content retrieval from internal sources while maintaining external web research capabilities through the reader API as fallback.