### PR TITLE
fix: remove leftover elements after AI content generation

### DIFF
--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -129,11 +129,40 @@ export default class AiAgentService {
 			const selection = model.document.selection;
 			const selectedContentFragment = model.getSelectedContent( selection );
 
-			const viewFragment = editor.data.toView( selectedContentFragment );
-			const html = editor.data.processor.toData( viewFragment );
+			const firstPos = selection.getFirstPosition();
+			const lastPos  = selection.getLastPosition();
+			const blocks = Array.from(selection.getSelectedBlocks());
+			const block = blocks[0];
+			let pathsEqual = false;
+			if (block) {
+				const range = model.createRangeIn(block);
+				const startLine = range.start.path;
+				const endLine = range.end.path;
+				const firstPosPath = firstPos?.path;
+				const lastPosPath = lastPos?.path;
+				
+				pathsEqual = Boolean(firstPosPath && lastPosPath && 
+					firstPosPath.length === startLine.length && 
+					lastPosPath.length === endLine.length &&
+					firstPosPath.every((val, i) => val === startLine[i]) &&
+					lastPosPath.every((val, i) => val === endLine[i]));
+				
+			}
 
+			if (pathsEqual && block) {
+				const fragHtml = editor.model.change( writer => {
+					const rangeOnBlock = writer.createRangeOn(block);
+					const frag = model.getSelectedContent( model.createSelection(rangeOnBlock) );
+					
+					const viewFrag = editor.data.toView(frag);
+					return editor.data.processor.toData(viewFrag);
+				});
+				selectedContent = fragHtml;
+			} else {
+				const viewFragment = editor.data.toView( selectedContentFragment );
+				selectedContent = editor.data.processor.toData( viewFragment );
+			}
 			content = command;
-			selectedContent = html;
 		}
 
 		if ( this.moderationEnable ) {
@@ -213,7 +242,7 @@ export default class AiAgentService {
 					content: contentMatch[1]
 				};
 			}
-			const x = false;
+
 			if ( AI_ENGINE.includes( this.aiEngine as any ) ) {
 				const config = {
 					apiKey: this.apiKey

--- a/src/util/ai-agent-button.ts
+++ b/src/util/ai-agent-button.ts
@@ -139,7 +139,6 @@ export function addAiAgentButton( editor: Editor ): void {
 						if ( event.key === 'Enter' && ( event.ctrlKey || event.metaKey ) && button.isEnabled ) {
 							event.preventDefault();
 							const command = textareaView.element?.value || '';
-							insertEmptySpace( editor );
 							executeAiAgentCommand( command, labeledFieldView as LabeledFieldView<TextareaView>, listView );
 						}
 					} );
@@ -153,7 +152,6 @@ export function addAiAgentButton( editor: Editor ): void {
 		// Execute a command when the button is clicked
 		button.on( 'execute', () => {
 			const command = ( labeledFieldView.fieldView as TextareaView ).element?.value || '';
-			insertEmptySpace( editor );
 			executeAiAgentCommand( command, labeledFieldView as LabeledFieldView<TextareaView>, listView );
 		} );
 
@@ -184,7 +182,6 @@ export function addAiAgentButton( editor: Editor ): void {
 				} );
 				buttonView.delegate( 'execute' ).to( menuView );
 				buttonView.on( 'execute', () => {
-					insertEmptySpace( editor );
 					executeAiAgentCommand( item.command, labeledFieldView, listView );
 				} );
 				listItemView.children.add( buttonView );
@@ -209,15 +206,6 @@ export function addAiAgentButton( editor: Editor ): void {
 	editor.editing.view.document.on( 'keydown', ( event, data ) => {
 		if ( ( data.ctrlKey || data.metaKey ) && data.keyCode === 191 ) {
 			executeCommand();
-		}
-	} );
-}
-
-function insertEmptySpace( editor: Editor ): void {
-	editor.model.change( writer => {
-		const insertPosition = editor.model.document.selection.getFirstPosition();
-		if ( insertPosition ) {
-			writer.insertText( '\u00A0', insertPosition );
 		}
 	} );
 }

--- a/src/util/process-content.ts
+++ b/src/util/process-content.ts
@@ -141,14 +141,20 @@ export class ProcessContentHelper {
 		const editorData = editor.getData();
 		let editorContent = editorData.replace( new RegExp( `<ai-tag id="${ blockID }-inline">&nbsp;</ai-tag>`, 'g' ), '' );
 		editorContent = editorContent.replace( new RegExp( `<ai-tag id="${ blockID }">&nbsp;</ai-tag>`, 'g' ), '' );
-		editorContent = editorContent.replace( /<\/ai-tag>\s*<[^>]+>\s*&nbsp;\s*<\/[^>]+>/g, '' );
+		editorContent = editorContent.replace( `</ai-tag>`, '' );
 		editorContent = editorContent.replace( `<ai-tag id="${ blockID }-inline">`, '' );
 		editorContent = editorContent.replace( `<ai-tag id="${ blockID }">`, '' );
 
-		editor.execute( 'selectAll' );
-		const viewFragment = editor.data.processor.toView( editorContent );
-		const modelFragment = editor.data.toModel( viewFragment );
-		editor.model.insertContent( modelFragment );
+		editor.model.change( writer => {
+			const root = editor.model.document.getRoot();
+			if ( root ) {
+				writer.remove( editor.model.createRangeIn( root ) );
+				
+				const viewFragment = editor.data.processor.toView( editorContent );
+				const modelFragment = editor.data.toModel( viewFragment );
+				writer.insert( modelFragment, root, 0 );
+			}
+		} );
 	}
 
 	/**


### PR DESCRIPTION
- Improve selection handling in aiagentservice.ts by checking if selection spans entire blocks
- Remove insertEmptySpace function calls that were adding unwanted non-breaking spaces
- Fix content processing to properly handle block-level selections without extra whitespace
- Replace selectAll + insertContent with direct model manipulation for cleaner content replacement

This resolves issue where AI agent would insert unwanted spaces and newlines when editing selected text, particularly when the selection spans entire blocks.

Closes #154