### PR TITLE
Update Node.js requirement to v24.11.0+

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '22' # Use the Node.js version your project requires
+          node-version: '24' # Use the Node.js version your project requires
 
       # Install dependencies
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '22' # Use the Node.js version your project requires
+          node-version: '24' # Use the Node.js version your project requires
 
       # Install dependencies
       - name: Install dependencies

--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4.0.2
         with:
-          node-version: '22'
+          node-version: '24'
           
       - name: Install dependencies
         run: |

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=24.11.0",
+    "node": ">=24.0.0",
     "npm": ">=5.7.1"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=24.11.0",
     "npm": ">=5.7.1"
   },
   "files": [
@@ -60,13 +60,13 @@
     "@typescript-eslint/parser": "^8.38.0",
     "ckeditor5": "^46.0.0",
     "eslint": "^9.32.0",
-    "eslint-config-ckeditor5": ">=12.1.0",
+    "eslint-config-ckeditor5": "^13.0.0",
     "http-server": "^14.1.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
     "sinon": "^21.0.0",
     "stylelint": "^16.23.0",
-    "stylelint-config-ckeditor5": ">=12.1.0",
+    "stylelint-config-ckeditor5": "^13.0.0",
     "ts-node": "^10.9.2",
     "typescript": "5.8.3",
     "webpack": "^5.101.0",


### PR DESCRIPTION
## Summary

Updates Node.js minimum version requirement to v24.11.0+ to support the latest CKEditor 5 tooling dependencies.

## Changes

- Update `engines.node` in `package.json` from `>=18.0.0` to `>=24.11.0`
- Update `eslint-config-ckeditor5` from `>=12.1.0` to `^13.0.0`
- Update `stylelint-config-ckeditor5` from `>=12.1.0` to `^13.0.0`

## Test plan

- [ ] Verify `yarn install` succeeds with Node.js v24.11.0+
- [ ] Verify build completes successfully
- [ ] Verify linting works correctly

Fixes #164