### PR TITLE
fix: only send providers param when using default model (kavya-m1)

### DIFF
--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -299,8 +299,8 @@ export default class AiAgentService {
 					editor: this.editor
 				};
 
-				// Add providers if engine is dxai and providers is set
-				if ( this.aiEngine === 'dxai' && this.providers ) {
+				// Add providers if engine is dxai and model is kavya-m1 (default model)
+				if ( this.aiEngine === 'dxai' && this.aiModel === 'kavya-m1' && this.providers ) {
 					config.providers = this.providers;
 				}
 


### PR DESCRIPTION
## Summary

- Only send `providers` parameter to the DXAI endpoint when using the default model (`kavya-m1`)

This aligns with the fix applied to DXPR Builder in commit `4a78aee60ed06a0ffe3c378e6209ffb4af582ab3`.

## Changes

In `aiagentservice.ts`, added a check for `kavya-m1` model before including providers in the config:

```diff
- // Add providers if engine is dxai and providers is set
- if ( this.aiEngine === 'dxai' && this.providers ) {
+ // Add providers if engine is dxai and model is kavya-m1 (default model)
+ if ( this.aiEngine === 'dxai' && this.aiModel === 'kavya-m1' && this.providers ) {
```

Closes #166

## Test plan

- [ ] Test AI generation with `dxai` engine and `kavya-m1` model (should send providers)
- [ ] Test AI generation with `dxai` engine and non-default model (should not send providers)