### PR TITLE
fix: use href="#" for blocked links instead of data attribute

### DIFF
--- a/src/util/ai-output-filter.ts
+++ b/src/util/ai-output-filter.ts
@@ -60,9 +60,6 @@ const SVG_IMAGE_SELECTOR = 'svg image';
 /** XLink namespace for SVG href attributes */
 const XLINK_NAMESPACE = 'http://www.w3.org/1999/xlink';
 
-/** Data attribute added to blocked links */
-const BLOCKED_LINK_ATTR = 'data-blocked-href';
-
 /** Maximum filename length for placeholders */
 const MAX_FILENAME_LENGTH = 50;
 
@@ -326,8 +323,7 @@ const filterHtmlContent = (
 		const href = anchor.getAttribute( 'href' ) || '';
 		if ( href && shouldBlockLinkUrl( href, config ) ) {
 			recordBlockedUrl( blockedUrls, href, 'link' );
-			anchor.removeAttribute( 'href' );
-			anchor.setAttribute( BLOCKED_LINK_ATTR, 'true' );
+			anchor.setAttribute( 'href', '#' );
 		}
 	} );
 


### PR DESCRIPTION
## Summary

- Blocked links now use `href="#"` instead of removing the href and adding `data-blocked-href="true"`

## Rationale

Using `href="#"` is simpler and keeps the link looking and behaving like a link (pointer cursor, focusable) while preventing navigation to potentially malicious URLs.

**Before:**
```html
<a data-blocked-href="true">Click here</a>
```

**After:**
```html
<a href="#">Click here</a>
```

Related to #159

## Test plan

- [ ] Test AI generation with blocked external links
- [ ] Verify blocked links show `href="#"` in the output
- [ ] Verify links still appear clickable but don't navigate anywhere dangerous