### PR TITLE
fix(security): filter plain text URLs in AI output

### DIFF
--- a/src/util/ai-output-filter.ts
+++ b/src/util/ai-output-filter.ts
@@ -7,6 +7,7 @@
  * Filters:
  * - Images: <img> tags and Markdown ![alt](url) syntax including reference-style (enabled by default)
  * - Links: <a> tags and Markdown [text](url) syntax including reference-style (enabled by default)
+ * - Plain text URLs: Bare http(s):// URLs in text content (replaced with EXTERNAL_URL_REDACTED)
  * - Iframes: All <iframe> tags are unconditionally removed (always enabled)
  * - Dangerous elements: <object>, <embed>, <applet>, SVG <image> (always enabled)
  *
@@ -66,6 +67,9 @@ const MAX_FILENAME_LENGTH = 50;
 /** Default filename when extraction fails */
 const DEFAULT_FILENAME = 'image';
 
+/** Replacement text for blocked plain text URLs */
+const REDACTED_URL_TEXT = 'EXTERNAL_URL_REDACTED';
+
 // Regex patterns
 const PATTERNS = {
 	/** Matches [refname]: url or [refname]: url "title" */
@@ -83,7 +87,12 @@ const PATTERNS = {
 	/** Detects HTML content */
 	htmlDetection: /<[^>]+>/,
 	/** Escapes regex special characters */
-	regexEscape: /[.*+?^${}()|[\]\\]/g
+	regexEscape: /[.*+?^${}()|[\]\\]/g,
+	/**
+	 * Matches plain text URLs (http:// or https://)
+	 * Captures URLs that are not already inside HTML attributes or markdown syntax.
+	 */
+	plainTextUrl: /https?:\/\/[^\s<>"')\]]+/gi
 } as const;
 
 // ============================================================================
@@ -250,6 +259,26 @@ const getReplacementImageSrc = ( originalUrl: string, config: ResolvedConfig ): 
 };
 
 /**
+ * Filters plain text URLs in content.
+ * Replaces blocked URLs with EXTERNAL_URL_REDACTED.
+ * This handles URLs that aren't wrapped in <a> tags or markdown link syntax.
+ */
+const filterPlainTextUrls = (
+	content: string,
+	config: ResolvedConfig,
+	blockedUrls: BlockedUrlInfo
+): string => {
+	const regex = new RegExp( PATTERNS.plainTextUrl.source, 'gi' );
+	return content.replace( regex, ( url: string ) => {
+		if ( shouldBlockLinkUrl( url, config ) ) {
+			recordBlockedUrl( blockedUrls, url, 'link' );
+			return REDACTED_URL_TEXT;
+		}
+		return url;
+	} );
+};
+
+/**
  * Parses reference-style definitions from Markdown content.
  */
 const parseMarkdownReferences = ( markdown: string ): Map<string, string> => {
@@ -324,6 +353,21 @@ const filterHtmlContent = (
 		if ( href && shouldBlockLinkUrl( href, config ) ) {
 			recordBlockedUrl( blockedUrls, href, 'link' );
 			anchor.setAttribute( 'href', '#' );
+		}
+	} );
+
+	// Filter plain text URLs in text nodes
+	const walker = doc.createTreeWalker( doc.body, NodeFilter.SHOW_TEXT, null );
+	const textNodes: Text[] = [];
+	let node: Text | null;
+	while ( ( node = walker.nextNode() as Text | null ) ) {
+		textNodes.push( node );
+	}
+	textNodes.forEach( textNode => {
+		const text = textNode.textContent || '';
+		const filtered = filterPlainTextUrls( text, config, blockedUrls );
+		if ( filtered !== text ) {
+			textNode.textContent = filtered;
 		}
 	} );
 
@@ -432,6 +476,9 @@ const filterMarkdownContent = (
 
 	// Clean up orphaned reference definitions
 	filtered = cleanupMarkdownReferences( filtered, markdown, config );
+
+	// Filter plain text URLs (not in markdown syntax)
+	filtered = filterPlainTextUrls( filtered, config, blockedUrls );
 
 	return filtered;
 };


### PR DESCRIPTION
## Summary
- Extends EchoLeak mitigation (CVE-2025-32711) to handle bare/plain text URLs
- Plain text URLs like `http://malicious.com/exfil?data=secret` are now replaced with `EXTERNAL_URL_REDACTED` unless the domain is in the `allowedLinkDomains` allowlist
- Applies filtering to both HTML text nodes and markdown content

## Problem
The original security fix (#161) filtered:
- `<img>` tags
- `<a>` tags
- Markdown `![alt](url)` and `[text](url)` syntax

But it **did not handle** plain text URLs like:
```html
<p>Check out http://example.com/science for more info.</p>
```

Attackers could use this gap to output URLs that:
- Users might copy/paste
- Could be auto-linked by other systems (email clients, chat apps)
- Could be manually navigated to by users

## Solution
- Added `plainTextUrl` regex pattern to detect bare `http://` and `https://` URLs
- Added `filterPlainTextUrls()` function that replaces blocked URLs with `EXTERNAL_URL_REDACTED`
- Integrated filtering into both:
  - `filterHtmlContent()` - walks text nodes
  - `filterMarkdownContent()` - processes text after other markdown filtering

## Test plan
- [ ] AI generates content with plain text URLs → blocked URLs replaced with `EXTERNAL_URL_REDACTED`
- [ ] URLs on allowed domains pass through unchanged
- [ ] URLs in `<a>` tags still work as before (neutralized href)
- [ ] URLs in markdown `[text](url)` still work as before
- [ ] Same-origin URLs pass through unchanged

Related: #159