### PR TITLE
fix(security): preserve pre-existing URLs during content rewrite

### DIFF
--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -16,6 +16,7 @@ import { getErrorMessages } from './util/translations.js';
 import { moderateContent } from './util/moderate-content.js';
 import { AIApi } from './util/ai-api.js';
 import { checkModel } from './util/check-model.js';
+import { setContextDomains, clearContextDomains } from './util/ai-output-filter.js';
 import type { AiModel, AiEngine, ModerationFlagsTypes, AIApiConfig } from './type-identifiers.js';
 import { aiAgentContext } from './aiagentcontext.js';
 import { AI_ENGINE } from './const.js';
@@ -197,6 +198,8 @@ export default class AiAgentService {
 				selectedContent
 			);
 			if ( parent && prompt ) {
+				// Set context domains for URL filtering - preserve URLs from user's prompt and existing content
+				setContextDomains( `${ content || '' } ${ selectedContent || '' } ${ parentEquivalentHTML?.innerHTML || '' }` );
 				await this.fetchAndProcessGptResponse( !!command, prompt, parent );
 			}
 		} catch ( error ) {
@@ -205,6 +208,7 @@ export default class AiAgentService {
 		} finally {
 			this.isInlineInsertion = false;
 			aiAgentContext.hideLoader( editor );
+			clearContextDomains();
 		}
 	}
 

--- a/src/util/ai-output-filter.ts
+++ b/src/util/ai-output-filter.ts
@@ -30,10 +30,59 @@ const ALLOWED_TAGS = new Set( [
 // Universal URL pattern - catches http://, https://, and protocol-relative //
 const URL_PATTERN = /(?:https?:)?\/\/[^\s"'<>)\]]+/gi;
 
+// Context domains - domains extracted from pre-existing content that should be preserved
+let contextDomains: Set<string> = new Set();
+
 export interface AiFilterConfig {
 	allowedDomains?: string[];
 	onUrlBlocked?: ( blockedUrls: string[] ) => void;
 }
+
+/**
+ * Extract hostname from a URL string.
+ */
+const extractHostname = ( url: string ): string | null => {
+	try {
+		const urlObj = new URL( url, typeof window !== 'undefined' ? window.location.href : undefined );
+		return urlObj.hostname.toLowerCase();
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * Extract unique domains from content (HTML or plain text).
+ * Used to preserve URLs that were already in the user's content.
+ */
+export const extractDomainsFromContent = ( content: string ): Set<string> => {
+	if ( !content ) return new Set();
+	const domains = new Set<string>();
+	const matches = content.match( URL_PATTERN ) || [];
+	const currentHostname = typeof window !== 'undefined' ? window.location.hostname : '';
+
+	for ( const url of matches ) {
+		const hostname = extractHostname( url );
+		if ( hostname && hostname !== currentHostname ) {
+			domains.add( hostname );
+		}
+	}
+	return domains;
+};
+
+/**
+ * Set context domains from pre-existing content.
+ * These domains will be allowed in addition to the configured allowedDomains.
+ */
+export const setContextDomains = ( content: string ): void => {
+	contextDomains = extractDomainsFromContent( content );
+};
+
+/**
+ * Clear context domains after an AI operation completes.
+ */
+export const clearContextDomains = (): void => {
+	contextDomains = new Set();
+};
 
 const isUrlAllowed = ( url: string, allowedDomains: string[] ): boolean => {
 	if ( !url ) return true;
@@ -56,6 +105,9 @@ const isUrlAllowed = ( url: string, allowedDomains: string[] ): boolean => {
 		}
 
 		if ( typeof window !== 'undefined' && hostname === window.location.hostname ) return true;
+
+		// Check context domains first (domains from pre-existing content)
+		if ( contextDomains.has( hostname.toLowerCase() ) ) return true;
 
 		return allowedDomains.some( pattern => {
 			if ( pattern === hostname ) return true;


### PR DESCRIPTION
## Summary

When AI rewrites content, external URLs that were already present in the user's content are now preserved instead of being filtered out.

The AI output URL filter (CVE-2025-32711 mitigation) was incorrectly removing external URLs that the user intentionally added to their page. This fix automatically whitelists domains found in the context passed to AI, distinguishing between:
- URLs already in user content (preserved)
- New URLs injected by AI (still filtered for security)

## Changes

**ai-output-filter.ts:**
- Add `contextDomains` Set to store domains from existing content
- Add `extractDomainsFromContent()` to extract unique domains from HTML/text
- Add `setContextDomains()` / `clearContextDomains()` exports
- Update `isUrlAllowed()` to check context domains before configured allowlist
- Use Set for O(1) domain lookups (vs array includes in dxpr_builder)

**aiagentservice.ts:**
- Call `setContextDomains()` with prompt + selectedContent + parentHTML before AI call
- Call `clearContextDomains()` in finally block after operation

## Test plan

- [ ] Test AI rewrite of content with external link - link should be preserved
- [ ] Test AI generation with new external URLs - should still be filtered
- [ ] Test that domains are cleared between operations
- [ ] Verify notification toast still appears for blocked URLs

Fixes #171
Related: dxpr/dxpr_builder#4047