### PR TITLE
Enable plugin when endpointUrl is provided without apiKey

### DIFF
--- a/src/aiagent.ts
+++ b/src/aiagent.ts
@@ -17,8 +17,9 @@ export default class AiAgent extends Plugin {
 
 		const config = editor.config.get( 'aiAgent' ) as AiAgentConfig || {};
 
-		// Check if plugin is enabled based on presence of API key
-		this.isEnabled = Boolean( config.apiKey );
+		// Check if plugin is enabled based on presence of API key or custom endpoint URL
+		// (custom endpoint URL allows proxied requests where API key is handled server-side)
+		this.isEnabled = Boolean( config.apiKey || config.endpointUrl );
 
 		// Set default values and merge with provided config
 		const defaultConfig = {


### PR DESCRIPTION
## Summary
- Allow plugin to be enabled with just `endpointUrl` (no `apiKey` required)
- Supports proxy endpoints where authentication is handled server-side

Fixes #173

## Test plan
- [ ] Configure plugin with only `endpointUrl` (no `apiKey`)
- [ ] Verify AI buttons appear in toolbar
- [ ] Verify AI generation works through proxy endpoint