### PR TITLE
Standardize UI component naming conventions

### DIFF
--- a/src/aiagentcontext.ts
+++ b/src/aiagentcontext.ts
@@ -27,8 +27,7 @@ export class AiAgentContext {
 
 	public showError( message: string ): void {
 		if ( this._uiComponent ) {
-			console.log( 'Showing error message...', message );
-			this._uiComponent.showGptErrorToolTip( message );
+			this._uiComponent.showErrorTooltip( message );
 		}
 	}
 

--- a/src/aiagentui.ts
+++ b/src/aiagentui.ts
@@ -33,9 +33,9 @@ const PLACEHOLDER_SHOW_DELAY = 100;
 const LOADER_POSITION_OFFSET = 10;
 
 export default class AiAgentUI extends Plugin {
-	public readonly PLACEHOLDER_TEXT_ID = 'slash-placeholder';
-	public readonly GPT_RESPONSE_LOADER_ID = 'gpt-response-loader';
-	public readonly GPT_RESPONSE_ERROR_ID = 'gpt-error';
+	public readonly PLACEHOLDER_TEXT_ID = 'ck-ai-agent-placeholder';
+	public readonly LOADER_ID = 'ck-ai-agent-loader';
+	public readonly ERROR_TOOLTIP_ID = 'ck-ai-agent-error';
 
 	private showErrorDuration: number = SHOW_ERROR_DURATION;
 	private readonly abortController = new AbortController();
@@ -114,7 +114,7 @@ export default class AiAgentUI extends Plugin {
 		registerAiTagSchema( editor );
 		registerAiAnimateStatusSchema( editor );
 
-		this.addGptErrorToolTip();
+		this.createErrorTooltip();
 		addAiAgentButton( editor );
 		addAiAgentToneButton( editor );
 
@@ -153,7 +153,7 @@ export default class AiAgentUI extends Plugin {
 		const contentLanguageCode = editor.locale.contentLanguage;
 		const supportedLanguages = SUPPORTED_LANGUAGES;
 		if ( !supportedLanguages.includes( contentLanguageCode ) ) {
-			this.showGptErrorToolTip( t( 'Unsupported language code' ) );
+			this.showErrorTooltip( t( 'Unsupported language code' ) );
 		}
 	}
 
@@ -293,7 +293,7 @@ export default class AiAgentUI extends Plugin {
 			placeholder.onclick = () => {
 				editor.focus();
 			};
-			placeholder.classList.add( 'place-holder' );
+			placeholder.classList.add( 'ck-ai-agent-placeholder' );
 			placeholder.textContent = t( 'Type / to request AI content' );
 
 			const parentPanelContent = editor.ui.view.editable.element?.parentElement;
@@ -321,7 +321,7 @@ export default class AiAgentUI extends Plugin {
 		const ele = editor.ui.view.editable.element?.parentElement?.querySelector( `#${ this.PLACEHOLDER_TEXT_ID }` ) as HTMLElement;
 		const isReadOnlyMode = this.editor.isReadOnly;
 		if ( ele && rect && !isReadOnlyMode ) {
-			ele.classList.add( 'show-place-holder' );
+			ele.classList.add( 'ck-ai-agent-placeholder--visible' );
 			ele.style.top = `${ rect.top }px`;
 			ele.style.left = `${ rect.left }px`;
 		} else if ( ele ) {
@@ -344,11 +344,11 @@ export default class AiAgentUI extends Plugin {
 	 * Adds a loader element to the document body for indicating processing.
 	 */
 	private addLoader( editor: Editor ): void {
-		const ele = editor.ui.view.editable.element?.parentElement?.querySelector( `#${ this.GPT_RESPONSE_LOADER_ID }` ) as HTMLElement;
+		const ele = editor.ui.view.editable.element?.parentElement?.querySelector( `#${ this.LOADER_ID }` ) as HTMLElement;
 		if ( !ele ) {
 			const loaderElement = document.createElement( 'div' );
-			loaderElement.id = this.GPT_RESPONSE_LOADER_ID;
-			loaderElement.classList.add( 'gpt-loader' );
+			loaderElement.id = this.LOADER_ID;
+			loaderElement.classList.add( 'ck-ai-agent-loader' );
 
 			const parentPanelContent = editor.ui.view.editable.element?.parentElement;
 			if ( parentPanelContent ) {
@@ -370,7 +370,7 @@ export default class AiAgentUI extends Plugin {
 	public showLoader( editor: Editor ): void {
 		this.addLoader( editor );
 		const ele = editor.ui.view.editable.element?.parentElement?.querySelector(
-			`#${ this.GPT_RESPONSE_LOADER_ID }`
+			`#${ this.LOADER_ID }`
 		) as HTMLElement | null;
 
 		const domSelection = window.getSelection();
@@ -388,7 +388,7 @@ export default class AiAgentUI extends Plugin {
 		if ( ele ) {
 			ele.style.left = `${ left + LOADER_POSITION_OFFSET }px`;
 			ele.style.top = `${ top + LOADER_POSITION_OFFSET }px`;
-			ele.classList.add( 'show-gpt-loader' );
+			ele.classList.add( 'ck-ai-agent-loader--visible' );
 		}
 	}
 
@@ -396,24 +396,24 @@ export default class AiAgentUI extends Plugin {
 	 * Hides the loader element from the document.
 	 */
 	public hideLoader( editor: Editor ): void {
-		const ele = editor.ui.view.editable.element?.parentElement?.querySelector( `#${ this.GPT_RESPONSE_LOADER_ID }` ) as HTMLElement;
+		const ele = editor.ui.view.editable.element?.parentElement?.querySelector( `#${ this.LOADER_ID }` ) as HTMLElement;
 		if ( ele ) {
 			ele.remove();
 		}
 	}
 
 	/**
-	 * Adds an error tooltip element to the document body for displaying error messages.
+	 * Creates an error tooltip element in the document body for displaying error messages.
 	 */
-	private addGptErrorToolTip(): void {
-		const existingElement = document.getElementById( this.GPT_RESPONSE_ERROR_ID );
+	private createErrorTooltip(): void {
+		const existingElement = document.getElementById( this.ERROR_TOOLTIP_ID );
 		if ( existingElement ) {
 			this.errorTooltipElement = existingElement;
 			return;
 		}
 		const tooltipElement = document.createElement( 'p' );
-		tooltipElement.id = this.GPT_RESPONSE_ERROR_ID;
-		tooltipElement.classList.add( 'response-error' );
+		tooltipElement.id = this.ERROR_TOOLTIP_ID;
+		tooltipElement.classList.add( 'ck-ai-agent-error' );
 		document.body.appendChild( tooltipElement );
 		this.errorTooltipElement = tooltipElement;
 	}
@@ -424,7 +424,7 @@ export default class AiAgentUI extends Plugin {
 	 * @param message - The error message to display in the tooltip.
 	 * @param options - Optional configuration for the tooltip.
 	 */
-	public showGptErrorToolTip(
+	public showErrorTooltip(
 		message: string,
 		options?: { type?: 'error' | 'warning'; html?: boolean; duration?: number }
 	): void {
@@ -434,12 +434,12 @@ export default class AiAgentUI extends Plugin {
 
 		const editorRect = view?.getBoundingClientRect();
 		if ( tooltipElement && editorRect ) {
-			tooltipElement.classList.remove( 'response-error--warning' );
+			tooltipElement.classList.remove( 'ck-ai-agent-error--warning' );
 			if ( options?.type === 'warning' ) {
-				tooltipElement.classList.add( 'response-error--warning' );
+				tooltipElement.classList.add( 'ck-ai-agent-error--warning' );
 			}
 
-			tooltipElement.classList.add( 'show-response-error' );
+			tooltipElement.classList.add( 'ck-ai-agent-error--visible' );
 
 			if ( options?.html ) {
 				tooltipElement.innerHTML = message;
@@ -449,7 +449,7 @@ export default class AiAgentUI extends Plugin {
 
 			const duration = options?.duration ?? this.showErrorDuration;
 			this.setTimeout( () => {
-				this.hideGptErrorToolTip();
+				this.hideErrorTooltip();
 			}, duration );
 		}
 	}
@@ -483,7 +483,7 @@ export default class AiAgentUI extends Plugin {
 			`${ blockedUrls.length } ${ urlWord } ${ t( 'blocked for security.' ) }<br>` +
 			`<ul class="blocked-urls-list">${ urlListItems.join( '' ) }</ul>`;
 
-		this.showGptErrorToolTip( message, { type: 'warning', html: true, duration: BLOCKED_URL_WARNING_DURATION } );
+		this.showErrorTooltip( message, { type: 'warning', html: true, duration: BLOCKED_URL_WARNING_DURATION } );
 	}
 
 	/**
@@ -498,9 +498,9 @@ export default class AiAgentUI extends Plugin {
 	/**
 	 * Hides the error tooltip element from the document.
 	 */
-	private hideGptErrorToolTip(): void {
+	private hideErrorTooltip(): void {
 		if ( this.errorTooltipElement ) {
-			this.errorTooltipElement.classList.remove( 'show-response-error' );
+			this.errorTooltipElement.classList.remove( 'ck-ai-agent-error--visible' );
 		}
 	}
 

--- a/theme/style.css
+++ b/theme/style.css
@@ -1,5 +1,5 @@
 /* style for placeholder */
-.place-holder {
+.ck-ai-agent-placeholder {
 	position: absolute;
 	z-index: -1;
 	opacity: 0;
@@ -10,19 +10,19 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.place-holder {
+	.ck-ai-agent-placeholder {
 		transition: none;
 	}
 }
 
-.show-place-holder {
+.ck-ai-agent-placeholder--visible {
 	opacity: 0.75;
 	transition-duration: 1s;
 	z-index: 100;
 }
 
 /* style for response loader */
-.gpt-loader {
+.ck-ai-agent-loader {
 	position: absolute;
 	width: 5px;
 	height: 5px;
@@ -34,12 +34,12 @@
 	opacity: 0;
 }
 
-.show-gpt-loader {
+.ck-ai-agent-loader--visible {
 	opacity: 1;
 }
 
-.gpt-loader:before,
-.gpt-loader:after {
+.ck-ai-agent-loader:before,
+.ck-ai-agent-loader:after {
 	content: "";
 	position: absolute;
 	inset: 0;
@@ -49,7 +49,7 @@
 	animation-delay: -0.5s;
 }
 
-.gpt-loader:after {
+.ck-ai-agent-loader:after {
 	animation-delay: -1s;
 }
 
@@ -59,9 +59,9 @@
 	}
 }
 
-/* style for response error */
+/* style for error tooltip */
 
-.response-error {
+.ck-ai-agent-error {
 	position: fixed;
 	z-index: 9999;
 	color: hsl(0, 0%, 100%);
@@ -82,35 +82,35 @@
 	box-shadow: 0 4px 12px hsla(0, 0%, 0%, 0.15);
 }
 
-.response-error--warning {
+.ck-ai-agent-error--warning {
 	background: hsl(45, 100%, 40%);
 	color: hsl(0, 0%, 10%);
 }
 
-.response-error--warning a {
+.ck-ai-agent-error--warning a {
 	color: hsl(220, 80%, 30%);
 	text-decoration: underline;
 }
 
-.response-error strong {
+.ck-ai-agent-error strong {
 	display: block;
 	font-size: 16px;
 	margin-bottom: 4px;
 }
 
-.response-error .blocked-urls-list {
+.ck-ai-agent-error .blocked-urls-list {
 	margin: 8px 0 0 0;
 	padding-left: 20px;
 	font-size: 12px;
 	opacity: 0.9;
 }
 
-.response-error .blocked-urls-list li {
+.ck-ai-agent-error .blocked-urls-list li {
 	margin-bottom: 2px;
 	word-break: break-all;
 }
 
-.show-response-error {
+.ck-ai-agent-error--visible {
 	opacity: 1;
 	pointer-events: auto;
 }
@@ -309,17 +309,17 @@
 
 /* Update loader animation */
 @media (prefers-reduced-motion: reduce) {
-	.gpt-loader,
-	.gpt-loader:before,
-	.gpt-loader:after {
+	.ck-ai-agent-loader,
+	.ck-ai-agent-loader:before,
+	.ck-ai-agent-loader:after {
 		animation: none;
 		box-shadow: 0 0 0 2px hsla(224, 100%, 3%, 0.377);
 	}
 }
 
-/* Update response error transitions */
+/* Update error tooltip transitions */
 @media (prefers-reduced-motion: reduce) {
-	.response-error {
+	.ck-ai-agent-error {
 		transition: none;
 	}
 }


### PR DESCRIPTION
## Summary

Align error tooltip, loader, and placeholder naming with established codebase patterns (`ck-ai-*` prefix for CSS, consistent method names).

### ID Changes
| Old | New |
|-----|-----|
| `gpt-error` | `ck-ai-agent-error` |
| `gpt-response-loader` | `ck-ai-agent-loader` |
| `slash-placeholder` | `ck-ai-agent-placeholder` |

### CSS Class Changes
| Old | New |
|-----|-----|
| `response-error` | `ck-ai-agent-error` |
| `show-response-error` | `ck-ai-agent-error--visible` |
| `response-error--warning` | `ck-ai-agent-error--warning` |
| `gpt-loader` | `ck-ai-agent-loader` |
| `show-gpt-loader` | `ck-ai-agent-loader--visible` |
| `place-holder` | `ck-ai-agent-placeholder` |
| `show-place-holder` | `ck-ai-agent-placeholder--visible` |

### Method Changes
| Old | New |
|-----|-----|
| `showGptErrorToolTip` | `showErrorTooltip` |
| `hideGptErrorToolTip` | `hideErrorTooltip` |
| `addGptErrorToolTip` | `createErrorTooltip` |

### Constant Changes
| Old | New |
|-----|-----|
| `GPT_RESPONSE_LOADER_ID` | `LOADER_ID` |
| `GPT_RESPONSE_ERROR_ID` | `ERROR_TOOLTIP_ID` |

This removes inaccurate "GPT" references (the plugin supports multiple AI providers) and follows the `ck-ai-*` naming pattern used elsewhere in the codebase.

**BREAKING CHANGE**: CSS class names changed. Users with custom styles targeting the old class names will need to update them.

Fixes #177

## Test plan

- [ ] Verify TypeScript compilation passes
- [ ] Test error tooltip display (trigger an error condition)
- [ ] Test loader display during AI generation
- [ ] Test placeholder display on empty lines
- [ ] Verify warning tooltip styling works (blocked URLs warning)