### PR TITLE
feat: dispatch custom DOM events for AI generation success/failure

### DIFF
--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -243,6 +243,7 @@ export default class AiAgentService {
 		resetTimeout();
 
 		const blockID = `ai-${ new Date().getTime() }`;
+		const generationStartTime = performance.now();
 		try {
 			let llm: LlmEngine | undefined;
 			let response;
@@ -327,6 +328,16 @@ export default class AiAgentService {
 				);
 				await this.handleStreamingResponse( response, blockID, parent, command, controller, llm, resetTimeout );
 			}
+
+			// Dispatch success event for external analytics integration
+			document.dispatchEvent( new CustomEvent( 'dxpr:ai:generation:success', {
+				detail: {
+					model: this.aiModel,
+					promptLength: prompt?.length || 0,
+					generationDurationMs: Math.round( performance.now() - generationStartTime ),
+					outputLength: this.processContentHelper.getLastOutputLength?.() || 0
+				}
+			} ) );
 		} catch ( error: any ) {
 			if ( this.abortGeneration ) {
 				return;
@@ -340,6 +351,17 @@ export default class AiAgentService {
 			} else {
 				errorMessage = error?.message?.trim();
 			}
+
+			// Dispatch failure event for external analytics integration
+			document.dispatchEvent( new CustomEvent( 'dxpr:ai:generation:failure', {
+				detail: {
+					model: this.aiModel,
+					promptLength: prompt?.length || 0,
+					generationDurationMs: Math.round( performance.now() - generationStartTime ),
+					errorType: error?.name || 'Error',
+					errorCode: error?.status || error?.code || ''
+				}
+			} ) );
 
 			aiAgentContext.showError( errorMessage );
 			this.processContentHelper.processCompleted( blockID );

--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -408,12 +408,11 @@ export default class AiAgentService {
 		let generatedContent = '';
 		const updateInterval = 1000 / this.writesPerSecond; // Calculate interval in ms
 
-		const updateContent = async () => {
-			if ( contentBuffer ) {
-				generatedContent = contentBuffer;
-				await this.processContentHelper.updateContent( contentBuffer, blockID );
-			}
-		};
+			const updateContent = async () => {
+				if ( contentBuffer ) {
+					await this.processContentHelper.updateContent( contentBuffer, blockID );
+				}
+			};
 
 		const updateContentTimer = setInterval( updateContent, updateInterval );
 		try {

--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -406,13 +406,13 @@ export default class AiAgentService {
 		let isFirstChunk = true;
 		let contentBuffer = '';
 		let generatedContent = '';
-			const updateInterval = 1000 / this.writesPerSecond; // Calculate interval in ms
+		const updateInterval = 1000 / this.writesPerSecond; // Calculate interval in ms
 
-			const updateContent = async () => {
-				if ( contentBuffer ) {
-					await this.processContentHelper.updateContent( contentBuffer, blockID );
-				}
-			};
+		const updateContent = async () => {
+			if ( contentBuffer ) {
+				await this.processContentHelper.updateContent( contentBuffer, blockID );
+			}
+		};
 
 		const updateContentTimer = setInterval( updateContent, updateInterval );
 		try {

--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -48,6 +48,17 @@ export default class AiAgentService {
 	private processContentHelper: ProcessContentHelper;
 	private readonly FILTERED_STRINGS = /```html|```|html\n|@@@cursor@@@/g;
 
+	private getOutputMetrics( content: string ): { outputLength: number; outputWordCount: number } {
+		const safeContent = content || '';
+		const outputLength = safeContent.length;
+		const tempElement = document.createElement( 'div' );
+		tempElement.innerHTML = safeContent;
+		const plainText = ( tempElement.textContent || tempElement.innerText || '' ).trim();
+		const outputWordCount = plainText ? plainText.split( /\s+/ ).length : 0;
+
+		return { outputLength, outputWordCount };
+	}
+
 	/**
 	 * Initializes the AiAgentService with the provided editor and configuration settings.
 	 *
@@ -247,6 +258,10 @@ export default class AiAgentService {
 		try {
 			let llm: LlmEngine | undefined;
 			let response;
+			let outputMetrics = {
+				outputLength: 0,
+				outputWordCount: 0
+			};
 
 			const contentMatch = prompt.match(
 				/<CONTEXT>([\s\S]*?)<\/CONTEXT>/,
@@ -287,14 +302,14 @@ export default class AiAgentService {
 				if ( this.streamContent ) {
 					// Streaming path
 					const stream = this.generate( llm, this.aiModel, messages, completionOpts );
-					await this.handleStreamingResponse( stream, blockID, parent, command, controller, llm, resetTimeout );
+					outputMetrics = await this.handleStreamingResponse( stream, blockID, parent, command, controller, llm, resetTimeout );
 				} else {
 					// Non-streaming path
 					const result = await llm.complete( this.aiModel, messages, completionOpts );
 					if ( !result.content ) {
 						throw new Error( t( 'Empty response from AI model' ) );
 					}
-					await this.handleNonStreamingResponse( result.content, blockID, parent, command );
+					outputMetrics = await this.handleNonStreamingResponse( result.content, blockID, parent, command );
 				}
 			} else {
 				const config: AIApiConfig = {
@@ -326,16 +341,18 @@ export default class AiAgentService {
 					controller,
 					retries
 				);
-				await this.handleStreamingResponse( response, blockID, parent, command, controller, llm, resetTimeout );
+				outputMetrics = await this.handleStreamingResponse( response, blockID, parent, command, controller, llm, resetTimeout );
 			}
 
 			// Dispatch success event for external analytics integration
 			document.dispatchEvent( new CustomEvent( 'dxpr:ai:generation:success', {
 				detail: {
 					model: this.aiModel,
+					responseModel: this.aiModel,
 					promptLength: prompt?.length || 0,
 					generationDurationMs: Math.round( performance.now() - generationStartTime ),
-					outputLength: this.processContentHelper.getLastOutputLength?.() || 0
+					outputLength: outputMetrics.outputLength,
+					outputWordCount: outputMetrics.outputWordCount
 				}
 			} ) );
 		} catch ( error: any ) {
@@ -381,13 +398,15 @@ export default class AiAgentService {
 		controller: AbortController,
 		llm: LlmEngine | undefined,
 		resetTimeout: () => void
-	): Promise<void> {
+	): Promise<{ outputLength: number; outputWordCount: number }> {
 		let isFirstChunk = true;
 		let contentBuffer = '';
+		let generatedContent = '';
 		const updateInterval = 1000 / this.writesPerSecond; // Calculate interval in ms
 
 		const updateContent = async () => {
 			if ( contentBuffer ) {
+				generatedContent = contentBuffer;
 				await this.processContentHelper.updateContent( contentBuffer, blockID );
 			}
 		};
@@ -424,9 +443,10 @@ export default class AiAgentService {
 			clearInterval( updateContentTimer );
 			await updateContent();
 			this.processContentHelper.processCompleted( blockID );
-			contentBuffer = '';
+			generatedContent = contentBuffer;
 		}
-		this.processContentHelper.processCompleted( blockID );
+
+		return this.getOutputMetrics( generatedContent );
 	}
 
 	private async handleNonStreamingResponse(
@@ -434,7 +454,7 @@ export default class AiAgentService {
 		blockID: string,
 		parent: Element,
 		command: boolean
-	): Promise<void> {
+	): Promise<{ outputLength: number; outputWordCount: number }> {
 		aiAgentContext.hideLoader(this.editor);
 		this.processContentHelper.insertAiTag( blockID );
 		this.processContentHelper.clearParentContent( parent, command );
@@ -447,6 +467,8 @@ export default class AiAgentService {
 			await this.htmlParser.insertSimpleHtml( filteredContent );
 		}
 		this.processContentHelper.processCompleted( blockID );
+
+		return this.getOutputMetrics( filteredContent );
 	}
 
 	/**

--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -240,6 +240,7 @@ export default class AiAgentService {
 		const editor = this.editor;
 		const t = editor.t;
 		const controller = new AbortController();
+		this.abortGeneration = false;
 
 		// Create a timeout that can be reset
 		let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -345,6 +346,9 @@ export default class AiAgentService {
 			}
 
 			// Dispatch success event for external analytics integration
+			if ( this.abortGeneration ) {
+				return;
+			}
 			document.dispatchEvent( new CustomEvent( 'dxpr:ai:generation:success', {
 				detail: {
 					model: this.aiModel,

--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -406,7 +406,7 @@ export default class AiAgentService {
 		let isFirstChunk = true;
 		let contentBuffer = '';
 		let generatedContent = '';
-		const updateInterval = 1000 / this.writesPerSecond; // Calculate interval in ms
+			const updateInterval = 1000 / this.writesPerSecond; // Calculate interval in ms
 
 			const updateContent = async () => {
 				if ( contentBuffer ) {


### PR DESCRIPTION
## Summary

- Dispatch `dxpr:ai:generation:success` CustomEvent on document after successful AI generation
- Dispatch `dxpr:ai:generation:failure` CustomEvent on document after failed AI generation
- Events include: `model`, `promptLength`, `generationDurationMs`, `outputLength` (success) / `errorType`, `errorCode` (failure)
- No hard dependency on dxpr_builder — events are standard DOM CustomEvents that any listener can consume

Relates to dxpr/dxpr_builder#4414

## Test plan

- [ ] Generate AI content in CKEditor → verify `dxpr:ai:generation:success` event dispatched on document
- [ ] Trigger AI generation failure → verify `dxpr:ai:generation:failure` event dispatched
- [ ] Verify no errors when no event listeners are attached