### PR TITLE
fix: refine error toast messaging for consistency and usability

### DIFF
--- a/src/aiagentservice.ts
+++ b/src/aiagentservice.ts
@@ -588,19 +588,19 @@ export default class AiAgentService {
 			if ( this.creditsUrl ) {
 				const safeUrl = this.escapeHtml( this.creditsUrl );
 				return {
-					message: `${ t( 'You\'ve run out of AI credits.' ) } <a href="${ safeUrl }" target="_blank" rel="noopener">${ t( 'Add credits' ) } &rarr;</a>`,
+					message: `${ t( 'AI credit limit reached.' ) } <a href="${ safeUrl }" target="_blank" rel="noopener">${ t( 'Top up your credits' ) } &rarr;</a>`,
 					options: { type: 'error', html: true }
 				};
 			}
 			return {
-				message: t( 'You\'ve run out of AI credits.' ),
+				message: t( 'AI credit limit reached.' ),
 				options: { type: 'error' }
 			};
 		}
 
 		if ( status === 401 ) {
 			return {
-				message: t( 'Invalid API key. Check your AI configuration.' ),
+				message: t( 'Authentication error. Please check your API credentials.' ),
 				options: { type: 'error' }
 			};
 		}
@@ -614,14 +614,14 @@ export default class AiAgentService {
 
 		if ( status >= 500 ) {
 			return {
-				message: t( 'The AI service is temporarily unavailable. Try again shortly.' ),
+				message: t( 'AI service is currently unavailable. Please try again later.' ),
 				options: { type: 'warning' }
 			};
 		}
 
 		if ( !status && error?.name === 'AbortError' ) {
 			return {
-				message: t( 'Request timed out. Check your connection and try again.' ),
+				message: t( 'Request timed out. Please try again later.' ),
 				options: { type: 'warning' }
 			};
 		}
@@ -631,8 +631,7 @@ export default class AiAgentService {
 		}
 
 		return {
-			message: error?.message?.trim() ||
-				t( 'We couldn\'t connect to the AI. Please check your internet connection.' ),
+			message: t( 'AI operation failed. Please try again.' ),
 			options: { type: 'warning' }
 		};
 	}


### PR DESCRIPTION
Closes #183

## Summary
- Refine all error toast messages based on Jakob Nielsen's usability heuristics
- Align messaging vocabulary and patterns with dxpr_builder for cross-product consistency

## Nielsen Heuristic Analysis

### #2: Match between system and the real world
**Before:** "Invalid API key. Check your AI configuration."
**After:** "Authentication error. Please check your API credentials."
**Why:** "Invalid" implies the user entered a wrong key. In reality, the key may have been revoked, expired, or rejected by the provider. "Authentication error" accurately describes the symptom without assigning blame.

### #4: Consistency and standards
Aligned vocabulary with dxpr_builder:
| Term | Before | After (matches dxpr_builder) |
|------|--------|------------------------------|
| Credits action | "Add credits" | "Top up your credits" |
| Auth object | "API key" / "AI configuration" | "API credentials" |
| Unavailability | "temporarily unavailable" / "shortly" | "currently unavailable" / "later" |
| Credit state | "You've run out of AI credits" | "AI credit limit reached" |

### #5: Error prevention
**Before:** Fallback exposed raw `error.message` text to users (technical, unhelpful).
**After:** Clean generic fallback: "AI operation failed. Please try again."

### #9: Help users recognize, diagnose, and recover from errors
**Before:** "Request timed out. Check your connection and try again." (blames user's connection when the AI provider may be slow)
**After:** "Request timed out. Please try again later." (neutral, no false attribution)

## Final Message Table

| Trigger | Type | Message |
|---------|------|---------|
| 402 (with creditsUrl) | error | AI credit limit reached. [Top up your credits ->] |
| 402 (no creditsUrl) | error | AI credit limit reached. |
| 401 | error | Authentication error. Please check your API credentials. |
| 429 | warning | Too many requests. Please wait a moment and try again. |
| 500+ | warning | AI service is currently unavailable. Please try again later. |
| Timeout | warning | Request timed out. Please try again later. |
| Other status | default | Existing getErrorMessages() translation |
| Fallback | warning | AI operation failed. Please try again. |

## Test plan
- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Trigger each error scenario and verify toast message matches the table above
- [ ] Compare messaging side-by-side with dxpr_builder error toasts for consistency