### PR TITLE
feat: add supported models table to README for SEO

### DIFF
--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -97,13 +97,34 @@ jobs:
               
               if (shouldUpdate) {
                 await fs.writeFile(filePath, JSON.stringify(modelsList, null, 2) + "\n");
-                
-                // Update only the model count in README.md
+
+                const displayNames = {
+                  dxai: "DXAI", google: "Google", openai: "OpenAI",
+                  anthropic: "Anthropic", mistralai: "Mistral AI",
+                  groq: "Groq", xai: "xAI", openrouter: "OpenRouter"
+                };
+                const cols = 4;
+                let tableLines = [];
+                for (const [engine, models] of Object.entries(modelsList)) {
+                  const name = displayNames[engine] || engine;
+                  tableLines.push("", `#### ${name}`, "", "| | | | |", "|---|---|---|---|");
+                  for (let i = 0; i < models.length; i += cols) {
+                    const row = [];
+                    for (let j = 0; j < cols; j++) row.push(models[i + j] || "");
+                    tableLines.push("| " + row.join(" | ") + " |");
+                  }
+                }
+                const modelTable = tableLines.join("\n");
+
                 const readmePath = "./README.md";
                 let readme = await fs.readFile(readmePath, "utf8");
                 readme = readme.replace(
                   /<!-- BEGIN_MODEL_COUNT -->\d+<!-- END_MODEL_COUNT -->/,
                   `<!-- BEGIN_MODEL_COUNT -->${totalModels}<!-- END_MODEL_COUNT -->`
+                );
+                readme = readme.replace(
+                  /<!-- BEGIN_MODEL_TABLE -->[\s\S]*?<!-- END_MODEL_TABLE -->/,
+                  `<!-- BEGIN_MODEL_TABLE -->${modelTable}\n\n<!-- END_MODEL_TABLE -->`
                 );
                 await fs.writeFile(readmePath, readme);
                 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,199 @@ note: This project is not part of CKEditor premium, it is a free plugin created 
 
 🤖 Natively supports <!-- BEGIN_MODEL_COUNT -->529<!-- END_MODEL_COUNT --> models, with additional support for any self-hosted model via Ollama.
 
+## Supported Models
+
+<details>
+<summary>View all supported models</summary>
+
+<!-- BEGIN_MODEL_TABLE -->
+
+#### DXAI
+
+| | | | |
+|---|---|---|---|
+| kavya-m1 | kavya-m1-eu | | |
+
+#### Google
+
+| | | | |
+|---|---|---|---|
+| lyria-3-pro-preview | lyria-3-clip-preview | gemma-4-31b-it | gemma-4-26b-a4b-it |
+| gemma-3n-e4b-it | gemma-3n-e2b-it | gemma-3-4b-it | gemma-3-27b-it |
+| gemma-3-1b-it | gemma-3-12b-it | gemini-robotics-er-1.6-preview | gemini-robotics-er-1.5-preview |
+| gemini-pro-latest | gemini-flash-lite-latest | gemini-flash-latest | gemini-3.1-pro-preview-customtools |
+| gemini-3.1-pro-preview | gemini-3.1-flash-tts-preview | gemini-3.1-flash-lite-preview | gemini-3-pro-preview |
+| gemini-3-flash-preview | gemini-2.5-pro | gemini-2.5-flash-lite | gemini-2.5-flash |
+| gemini-2.0-flash-lite-001 | gemini-2.0-flash-lite | gemini-2.0-flash-001 | gemini-2.0-flash |
+| deep-research-pro-preview-12-2025 | deep-research-preview-04-2026 | deep-research-max-preview-04-2026 | |
+
+#### OpenAI
+
+| | | | |
+|---|---|---|---|
+| gpt-5.5-pro-2026-04-23 | gpt-5.5-pro | gpt-5.5-2026-04-23 | gpt-5.5 |
+| gpt-5.4-mini | gpt-5.4-mini-2026-03-17 | gpt-5.4-nano | gpt-5.4-nano-2026-03-17 |
+| gpt-5.4 | gpt-5.4-pro-2026-03-05 | gpt-5.4-pro | gpt-5.4-2026-03-05 |
+| gpt-5.3-chat-latest | gpt-5.3-codex | gpt-5.2-codex | gpt-5.2-chat-latest |
+| gpt-5.2-pro | gpt-5.2-pro-2025-12-11 | gpt-5.2 | gpt-5.2-2025-12-11 |
+| gpt-5.1-codex-max | gpt-5.1-codex-mini | gpt-5.1-codex | gpt-5.1 |
+| gpt-5.1-2025-11-13 | gpt-5.1-chat-latest | gpt-5-pro | gpt-5-pro-2025-10-06 |
+| gpt-5-codex | gpt-5-nano | gpt-5-nano-2025-08-07 | gpt-5-mini |
+| gpt-5-mini-2025-08-07 | gpt-5 | gpt-5-2025-08-07 | gpt-5-chat-latest |
+| o3-pro-2025-06-10 | o3-pro | gpt-4.1-nano | gpt-4.1-nano-2025-04-14 |
+| gpt-4.1-mini | gpt-4.1-mini-2025-04-14 | gpt-4.1 | gpt-4.1-2025-04-14 |
+| o4-mini | o3 | o4-mini-2025-04-16 | o3-2025-04-16 |
+| o1-pro | o1-pro-2025-03-19 | gpt-4o-2024-11-20 | o3-mini-2025-01-31 |
+| o3-mini | o1 | o1-2024-12-17 | gpt-4o-2024-08-06 |
+| gpt-4o-mini | gpt-4o-mini-2024-07-18 | gpt-4o-2024-05-13 | gpt-4o |
+| gpt-4-turbo-2024-04-09 | gpt-4-turbo | gpt-3.5-turbo-0125 | gpt-3.5-turbo-1106 |
+| gpt-3.5-turbo-instruct-0914 | gpt-3.5-turbo-instruct | gpt-4 | gpt-4-0613 |
+| gpt-3.5-turbo-16k | gpt-3.5-turbo | | |
+
+#### Anthropic
+
+| | | | |
+|---|---|---|---|
+| claude-opus-4-7 | claude-sonnet-4-6 | claude-opus-4-6 | claude-opus-4-5-20251101 |
+| claude-haiku-4-5-20251001 | claude-sonnet-4-5-20250929 | claude-opus-4-1-20250805 | claude-opus-4-20250514 |
+| claude-sonnet-4-20250514 | | | |
+
+#### Mistral AI
+
+| | | | |
+|---|---|---|---|
+| codestral-latest | devstral-2512 | devstral-medium-latest | devstral-latest |
+| devstral-medium-2507 | devstral-small-2507 | labs-leanstral-2603 | labs-mistral-small-creative |
+| magistral-medium-latest | magistral-small-latest | ministral-14b-latest | ministral-3b-latest |
+| ministral-8b-latest | mistral-large-2411 | mistral-large-2512 | mistral-large-latest |
+| mistral-medium-2505 | mistral-medium-latest | mistral-small-2506 | mistral-small-latest |
+| mistral-tiny-latest | mistral-vibe-cli-latest | pixtral-large-latest | voxtral-mini-latest |
+| voxtral-small-latest | | | |
+
+#### Groq
+
+| | | | |
+|---|---|---|---|
+| canopylabs/orpheus-v1-english | canopylabs/orpheus-arabic-saudi | groq/compound-mini | groq/compound |
+| openai/gpt-oss-120b | openai/gpt-oss-20b | qwen/qwen3-32b | meta-llama/llama-4-scout-17b-16e-instruct |
+| allam-2-7b | llama-3.3-70b-versatile | llama-3.1-8b-instant | |
+
+#### xAI
+
+| | | | |
+|---|---|---|---|
+| grok-4.20-0309-non-reasoning | grok-4.20-0309-reasoning | grok-4.20-multi-agent-0309 | grok-imagine-video |
+| grok-4-1-fast-non-reasoning | grok-4-1-fast-reasoning | grok-4-fast-non-reasoning | grok-4-fast-reasoning |
+| grok-code-fast-1 | grok-4-0709 | grok-3 | grok-3-mini |
+
+#### OpenRouter
+
+| | | | |
+|---|---|---|---|
+| ai21/jamba-large-1.7 | aion-labs/aion-1.0 | aion-labs/aion-1.0-mini | aion-labs/aion-2.0 |
+| aion-labs/aion-rp-llama-3.1-8b | alfredpros/codellama-7b-instruct-solidity | allenai/olmo-3-32b-think | allenai/olmo-3.1-32b-instruct |
+| amazon/nova-2-lite-v1 | amazon/nova-lite-v1 | amazon/nova-micro-v1 | amazon/nova-premier-v1 |
+| amazon/nova-pro-v1 | ~anthropic/claude-haiku-latest | ~anthropic/claude-sonnet-latest | anthropic/claude-3-haiku |
+| anthropic/claude-3.5-haiku | anthropic/claude-3.7-sonnet | anthropic/claude-3.7-sonnet:thinking | anthropic/claude-haiku-4.5 |
+| anthropic/claude-opus-4 | anthropic/claude-opus-4.1 | anthropic/claude-opus-4.5 | anthropic/claude-opus-4.6 |
+| anthropic/claude-opus-4.6-fast | anthropic/claude-opus-4.7 | ~anthropic/claude-opus-latest | anthropic/claude-sonnet-4 |
+| anthropic/claude-sonnet-4.5 | anthropic/claude-sonnet-4.6 | arcee-ai/coder-large | arcee-ai/maestro-reasoning |
+| arcee-ai/spotlight | arcee-ai/trinity-large-preview | arcee-ai/trinity-large-thinking | arcee-ai/trinity-mini |
+| arcee-ai/virtuoso-large | openrouter/auto | baidu/ernie-4.5-21b-a3b | baidu/ernie-4.5-21b-a3b-thinking |
+| baidu/ernie-4.5-300b-a47b | baidu/ernie-4.5-vl-28b-a3b | baidu/ernie-4.5-vl-424b-a47b | baidu/qianfan-ocr-fast:free |
+| openrouter/bodybuilder | bytedance-seed/seed-1.6 | bytedance-seed/seed-1.6-flash | bytedance-seed/seed-2.0-lite |
+| bytedance-seed/seed-2.0-mini | bytedance/ui-tars-1.5-7b | cohere/command-a | cohere/command-r-08-2024 |
+| cohere/command-r-plus-08-2024 | cohere/command-r7b-12-2024 | deepcogito/cogito-v2.1-671b | deepseek/deepseek-chat |
+| deepseek/deepseek-chat-v3-0324 | deepseek/deepseek-chat-v3.1 | deepseek/deepseek-v3.1-terminus | deepseek/deepseek-v3.2 |
+| deepseek/deepseek-v3.2-exp | deepseek/deepseek-v3.2-speciale | deepseek/deepseek-v4-flash | deepseek/deepseek-v4-pro |
+| deepseek/deepseek-r1 | deepseek/deepseek-r1-0528 | deepseek/deepseek-r1-distill-llama-70b | deepseek/deepseek-r1-distill-qwen-32b |
+| essentialai/rnj-1-instruct | openrouter/free | alpindale/goliath-120b | ~google/gemini-flash-latest |
+| ~google/gemini-pro-latest | google/gemini-2.0-flash-001 | google/gemini-2.0-flash-lite-001 | google/gemini-2.5-flash |
+| google/gemini-2.5-flash-lite | google/gemini-2.5-flash-lite-preview-09-2025 | google/gemini-2.5-pro | google/gemini-2.5-pro-preview-05-06 |
+| google/gemini-2.5-pro-preview | google/gemini-3-flash-preview | google/gemini-3.1-flash-lite-preview | google/gemini-3.1-pro-preview |
+| google/gemini-3.1-pro-preview-customtools | google/gemma-2-27b-it | google/gemma-3-12b-it | google/gemma-3-12b-it:free |
+| google/gemma-3-27b-it | google/gemma-3-27b-it:free | google/gemma-3-4b-it | google/gemma-3-4b-it:free |
+| google/gemma-3n-e2b-it:free | google/gemma-3n-e4b-it | google/gemma-3n-e4b-it:free | google/gemma-4-26b-a4b-it |
+| google/gemma-4-26b-a4b-it:free | google/gemma-4-31b-it | google/gemma-4-31b-it:free | google/lyria-3-clip-preview |
+| google/lyria-3-pro-preview | google/gemini-2.5-flash-image | google/gemini-3.1-flash-image-preview | google/gemini-3-pro-image-preview |
+| ibm-granite/granite-4.0-h-micro | inception/mercury-2 | inclusionai/ling-2.6-1t:free | inclusionai/ling-2.6-flash |
+| inflection/inflection-3-pi | inflection/inflection-3-productivity | kwaipilot/kat-coder-pro-v2 | liquid/lfm-2-24b-a2b |
+| liquid/lfm-2.5-1.2b-instruct:free | liquid/lfm-2.5-1.2b-thinking:free | meta-llama/llama-guard-3-8b | anthracite-org/magnum-v4-72b |
+| mancer/weaver | meta-llama/llama-3-70b-instruct | meta-llama/llama-3-8b-instruct | meta-llama/llama-3.1-70b-instruct |
+| meta-llama/llama-3.1-8b-instruct | meta-llama/llama-3.2-11b-vision-instruct | meta-llama/llama-3.2-1b-instruct | meta-llama/llama-3.2-3b-instruct |
+| meta-llama/llama-3.2-3b-instruct:free | meta-llama/llama-3.3-70b-instruct | meta-llama/llama-3.3-70b-instruct:free | meta-llama/llama-4-maverick |
+| meta-llama/llama-4-scout | meta-llama/llama-guard-4-12b | microsoft/phi-4 | minimax/minimax-m1 |
+| minimax/minimax-m2 | minimax/minimax-m2-her | minimax/minimax-m2.1 | minimax/minimax-m2.5 |
+| minimax/minimax-m2.5:free | minimax/minimax-m2.7 | minimax/minimax-01 | mistralai/mistral-large |
+| mistralai/mistral-large-2407 | mistralai/mistral-large-2411 | mistralai/codestral-2508 | mistralai/devstral-2512 |
+| mistralai/devstral-medium | mistralai/devstral-small | mistralai/ministral-14b-2512 | mistralai/ministral-3b-2512 |
+| mistralai/ministral-8b-2512 | mistralai/mistral-7b-instruct-v0.1 | mistralai/mistral-large-2512 | mistralai/mistral-medium-3 |
+| mistralai/mistral-medium-3.1 | mistralai/mistral-nemo | mistralai/mistral-small-24b-instruct-2501 | mistralai/mistral-small-3.1-24b-instruct |
+| mistralai/mistral-small-3.2-24b-instruct | mistralai/mistral-small-2603 | mistralai/mistral-small-creative | mistralai/mixtral-8x22b-instruct |
+| mistralai/mixtral-8x7b-instruct | mistralai/pixtral-large-2411 | mistralai/mistral-saba | mistralai/voxtral-small-24b-2507 |
+| ~moonshotai/kimi-latest | moonshotai/kimi-k2 | moonshotai/kimi-k2-0905 | moonshotai/kimi-k2-thinking |
+| moonshotai/kimi-k2.5 | moonshotai/kimi-k2.6 | morph/morph-v3-fast | morph/morph-v3-large |
+| gryphe/mythomax-l2-13b | nex-agi/deepseek-v3.1-nex-n1 | nousresearch/hermes-3-llama-3.1-405b | nousresearch/hermes-3-llama-3.1-405b:free |
+| nousresearch/hermes-3-llama-3.1-70b | nousresearch/hermes-4-405b | nousresearch/hermes-4-70b | nousresearch/hermes-2-pro-llama-3-8b |
+| nvidia/llama-3.1-nemotron-70b-instruct | nvidia/llama-3.3-nemotron-super-49b-v1.5 | nvidia/nemotron-3-nano-30b-a3b | nvidia/nemotron-3-nano-30b-a3b:free |
+| nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free | nvidia/nemotron-3-super-120b-a12b | nvidia/nemotron-3-super-120b-a12b:free | nvidia/nemotron-nano-12b-v2-vl |
+| nvidia/nemotron-nano-12b-v2-vl:free | nvidia/nemotron-nano-9b-v2 | nvidia/nemotron-nano-9b-v2:free | ~openai/gpt-latest |
+| ~openai/gpt-mini-latest | openai/gpt-audio | openai/gpt-audio-mini | openai/gpt-3.5-turbo |
+| openai/gpt-3.5-turbo-0613 | openai/gpt-3.5-turbo-16k | openai/gpt-3.5-turbo-instruct | openai/gpt-4 |
+| openai/gpt-4-0314 | openai/gpt-4-turbo | openai/gpt-4-1106-preview | openai/gpt-4-turbo-preview |
+| openai/gpt-4.1 | openai/gpt-4.1-mini | openai/gpt-4.1-nano | openai/gpt-4o |
+| openai/gpt-4o-2024-05-13 | openai/gpt-4o-2024-08-06 | openai/gpt-4o-2024-11-20 | openai/gpt-4o-audio-preview |
+| openai/gpt-4o-search-preview | openai/gpt-4o-mini | openai/gpt-4o-mini-2024-07-18 | openai/gpt-4o-mini-search-preview |
+| openai/gpt-5 | openai/gpt-5-chat | openai/gpt-5-codex | openai/gpt-5-image |
+| openai/gpt-5-image-mini | openai/gpt-5-mini | openai/gpt-5-nano | openai/gpt-5-pro |
+| openai/gpt-5.1 | openai/gpt-5.1-chat | openai/gpt-5.1-codex | openai/gpt-5.1-codex-max |
+| openai/gpt-5.1-codex-mini | openai/gpt-5.2 | openai/gpt-5.2-chat | openai/gpt-5.2-pro |
+| openai/gpt-5.2-codex | openai/gpt-5.3-chat | openai/gpt-5.3-codex | openai/gpt-5.4 |
+| openai/gpt-5.4-image-2 | openai/gpt-5.4-mini | openai/gpt-5.4-nano | openai/gpt-5.4-pro |
+| openai/gpt-5.5 | openai/gpt-5.5-pro | openai/gpt-oss-120b | openai/gpt-oss-120b:free |
+| openai/gpt-oss-20b | openai/gpt-oss-20b:free | openai/gpt-oss-safeguard-20b | openai/o1 |
+| openai/o1-pro | openai/o3 | openai/o3-deep-research | openai/o3-mini |
+| openai/o3-mini-high | openai/o3-pro | openai/o4-mini | openai/o4-mini-deep-research |
+| openai/o4-mini-high | openrouter/pareto-code | perplexity/sonar | perplexity/sonar-deep-research |
+| perplexity/sonar-pro | perplexity/sonar-pro-search | perplexity/sonar-reasoning-pro | poolside/laguna-m.1:free |
+| poolside/laguna-xs.2:free | prime-intellect/intellect-3 | qwen/qwen-plus-2025-07-28 | qwen/qwen-plus-2025-07-28:thinking |
+| qwen/qwen-vl-max | qwen/qwen-vl-plus | qwen/qwen-max | qwen/qwen-plus |
+| qwen/qwen-turbo | qwen/qwen-2.5-7b-instruct | qwen/qwen2.5-vl-72b-instruct | qwen/qwen3-14b |
+| qwen/qwen3-235b-a22b | qwen/qwen3-235b-a22b-2507 | qwen/qwen3-235b-a22b-thinking-2507 | qwen/qwen3-30b-a3b |
+| qwen/qwen3-30b-a3b-instruct-2507 | qwen/qwen3-30b-a3b-thinking-2507 | qwen/qwen3-32b | qwen/qwen3-8b |
+| qwen/qwen3-coder-30b-a3b-instruct | qwen/qwen3-coder | qwen/qwen3-coder:free | qwen/qwen3-coder-flash |
+| qwen/qwen3-coder-next | qwen/qwen3-coder-plus | qwen/qwen3-max | qwen/qwen3-max-thinking |
+| qwen/qwen3-next-80b-a3b-instruct | qwen/qwen3-next-80b-a3b-instruct:free | qwen/qwen3-next-80b-a3b-thinking | qwen/qwen3-vl-235b-a22b-instruct |
+| qwen/qwen3-vl-235b-a22b-thinking | qwen/qwen3-vl-30b-a3b-instruct | qwen/qwen3-vl-30b-a3b-thinking | qwen/qwen3-vl-32b-instruct |
+| qwen/qwen3-vl-8b-instruct | qwen/qwen3-vl-8b-thinking | qwen/qwen3.5-397b-a17b | qwen/qwen3.5-plus-02-15 |
+| qwen/qwen3.5-plus-20260420 | qwen/qwen3.5-122b-a10b | qwen/qwen3.5-27b | qwen/qwen3.5-35b-a3b |
+| qwen/qwen3.5-9b | qwen/qwen3.5-flash-02-23 | qwen/qwen3.6-27b | qwen/qwen3.6-35b-a3b |
+| qwen/qwen3.6-flash | qwen/qwen3.6-max-preview | qwen/qwen3.6-plus | qwen/qwen-2.5-72b-instruct |
+| qwen/qwen-2.5-coder-32b-instruct | rekaai/reka-edge | rekaai/reka-flash-3 | relace/relace-apply-3 |
+| relace/relace-search | undi95/remm-slerp-l2-13b | sao10k/l3-lunaris-8b | sao10k/l3-euryale-70b |
+| sao10k/l3.1-70b-hanami-x1 | sao10k/l3.1-euryale-70b | sao10k/l3.3-euryale-70b | stepfun/step-3.5-flash |
+| switchpoint/router | tencent/hunyuan-a13b-instruct | tencent/hy3-preview:free | thedrummer/cydonia-24b-v4.1 |
+| thedrummer/rocinante-12b | thedrummer/skyfall-36b-v2 | thedrummer/unslopnemo-12b | tngtech/deepseek-r1t2-chimera |
+| alibaba/tongyi-deepresearch-30b-a3b | upstage/solar-pro-3 | cognitivecomputations/dolphin-mistral-24b-venice-edition:free | microsoft/wizardlm-2-8x22b |
+| writer/palmyra-x5 | x-ai/grok-3 | x-ai/grok-3-beta | x-ai/grok-3-mini |
+| x-ai/grok-3-mini-beta | x-ai/grok-4 | x-ai/grok-4-fast | x-ai/grok-4.1-fast |
+| x-ai/grok-4.20 | x-ai/grok-4.20-multi-agent | x-ai/grok-code-fast-1 | xiaomi/mimo-v2-flash |
+| xiaomi/mimo-v2-omni | xiaomi/mimo-v2-pro | xiaomi/mimo-v2.5 | xiaomi/mimo-v2.5-pro |
+| z-ai/glm-4-32b | z-ai/glm-4.5 | z-ai/glm-4.5-air | z-ai/glm-4.5-air:free |
+| z-ai/glm-4.5v | z-ai/glm-4.6 | z-ai/glm-4.6v | z-ai/glm-4.7 |
+| z-ai/glm-4.7-flash | z-ai/glm-5 | z-ai/glm-5-turbo | z-ai/glm-5.1 |
+| z-ai/glm-5v-turbo | | | |
+
+<!-- END_MODEL_TABLE -->
+
+</details>
+
 ![image](https://github.com/dxpr/ckeditor5-ai-agent/blob/1.x/sample/images/toolbar-switching.gif)
 Video of AI Agent returning optimal HTML structure based on what is available in the toolbar, when a user prompt is "incorrect". After switching the editor configuration from "Full HTML" to "Basic HTML," an unordered list is generated instead of a table, using bold and normal-weight text to simulate some table-like structure.
 
 ## Table of Contents
 
+- [Supported Models](#supported-models)
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [How to Use](#how-to-use)

--- a/README.md
+++ b/README.md
@@ -22,199 +22,11 @@ note: This project is not part of CKEditor premium, it is a free plugin created 
 
 🤖 Natively supports <!-- BEGIN_MODEL_COUNT -->529<!-- END_MODEL_COUNT --> models, with additional support for any self-hosted model via Ollama.
 
-## Supported Models
-
-<details>
-<summary>View all supported models</summary>
-
-<!-- BEGIN_MODEL_TABLE -->
-
-#### DXAI
-
-| | | | |
-|---|---|---|---|
-| kavya-m1 | kavya-m1-eu | | |
-
-#### Google
-
-| | | | |
-|---|---|---|---|
-| lyria-3-pro-preview | lyria-3-clip-preview | gemma-4-31b-it | gemma-4-26b-a4b-it |
-| gemma-3n-e4b-it | gemma-3n-e2b-it | gemma-3-4b-it | gemma-3-27b-it |
-| gemma-3-1b-it | gemma-3-12b-it | gemini-robotics-er-1.6-preview | gemini-robotics-er-1.5-preview |
-| gemini-pro-latest | gemini-flash-lite-latest | gemini-flash-latest | gemini-3.1-pro-preview-customtools |
-| gemini-3.1-pro-preview | gemini-3.1-flash-tts-preview | gemini-3.1-flash-lite-preview | gemini-3-pro-preview |
-| gemini-3-flash-preview | gemini-2.5-pro | gemini-2.5-flash-lite | gemini-2.5-flash |
-| gemini-2.0-flash-lite-001 | gemini-2.0-flash-lite | gemini-2.0-flash-001 | gemini-2.0-flash |
-| deep-research-pro-preview-12-2025 | deep-research-preview-04-2026 | deep-research-max-preview-04-2026 | |
-
-#### OpenAI
-
-| | | | |
-|---|---|---|---|
-| gpt-5.5-pro-2026-04-23 | gpt-5.5-pro | gpt-5.5-2026-04-23 | gpt-5.5 |
-| gpt-5.4-mini | gpt-5.4-mini-2026-03-17 | gpt-5.4-nano | gpt-5.4-nano-2026-03-17 |
-| gpt-5.4 | gpt-5.4-pro-2026-03-05 | gpt-5.4-pro | gpt-5.4-2026-03-05 |
-| gpt-5.3-chat-latest | gpt-5.3-codex | gpt-5.2-codex | gpt-5.2-chat-latest |
-| gpt-5.2-pro | gpt-5.2-pro-2025-12-11 | gpt-5.2 | gpt-5.2-2025-12-11 |
-| gpt-5.1-codex-max | gpt-5.1-codex-mini | gpt-5.1-codex | gpt-5.1 |
-| gpt-5.1-2025-11-13 | gpt-5.1-chat-latest | gpt-5-pro | gpt-5-pro-2025-10-06 |
-| gpt-5-codex | gpt-5-nano | gpt-5-nano-2025-08-07 | gpt-5-mini |
-| gpt-5-mini-2025-08-07 | gpt-5 | gpt-5-2025-08-07 | gpt-5-chat-latest |
-| o3-pro-2025-06-10 | o3-pro | gpt-4.1-nano | gpt-4.1-nano-2025-04-14 |
-| gpt-4.1-mini | gpt-4.1-mini-2025-04-14 | gpt-4.1 | gpt-4.1-2025-04-14 |
-| o4-mini | o3 | o4-mini-2025-04-16 | o3-2025-04-16 |
-| o1-pro | o1-pro-2025-03-19 | gpt-4o-2024-11-20 | o3-mini-2025-01-31 |
-| o3-mini | o1 | o1-2024-12-17 | gpt-4o-2024-08-06 |
-| gpt-4o-mini | gpt-4o-mini-2024-07-18 | gpt-4o-2024-05-13 | gpt-4o |
-| gpt-4-turbo-2024-04-09 | gpt-4-turbo | gpt-3.5-turbo-0125 | gpt-3.5-turbo-1106 |
-| gpt-3.5-turbo-instruct-0914 | gpt-3.5-turbo-instruct | gpt-4 | gpt-4-0613 |
-| gpt-3.5-turbo-16k | gpt-3.5-turbo | | |
-
-#### Anthropic
-
-| | | | |
-|---|---|---|---|
-| claude-opus-4-7 | claude-sonnet-4-6 | claude-opus-4-6 | claude-opus-4-5-20251101 |
-| claude-haiku-4-5-20251001 | claude-sonnet-4-5-20250929 | claude-opus-4-1-20250805 | claude-opus-4-20250514 |
-| claude-sonnet-4-20250514 | | | |
-
-#### Mistral AI
-
-| | | | |
-|---|---|---|---|
-| codestral-latest | devstral-2512 | devstral-medium-latest | devstral-latest |
-| devstral-medium-2507 | devstral-small-2507 | labs-leanstral-2603 | labs-mistral-small-creative |
-| magistral-medium-latest | magistral-small-latest | ministral-14b-latest | ministral-3b-latest |
-| ministral-8b-latest | mistral-large-2411 | mistral-large-2512 | mistral-large-latest |
-| mistral-medium-2505 | mistral-medium-latest | mistral-small-2506 | mistral-small-latest |
-| mistral-tiny-latest | mistral-vibe-cli-latest | pixtral-large-latest | voxtral-mini-latest |
-| voxtral-small-latest | | | |
-
-#### Groq
-
-| | | | |
-|---|---|---|---|
-| canopylabs/orpheus-v1-english | canopylabs/orpheus-arabic-saudi | groq/compound-mini | groq/compound |
-| openai/gpt-oss-120b | openai/gpt-oss-20b | qwen/qwen3-32b | meta-llama/llama-4-scout-17b-16e-instruct |
-| allam-2-7b | llama-3.3-70b-versatile | llama-3.1-8b-instant | |
-
-#### xAI
-
-| | | | |
-|---|---|---|---|
-| grok-4.20-0309-non-reasoning | grok-4.20-0309-reasoning | grok-4.20-multi-agent-0309 | grok-imagine-video |
-| grok-4-1-fast-non-reasoning | grok-4-1-fast-reasoning | grok-4-fast-non-reasoning | grok-4-fast-reasoning |
-| grok-code-fast-1 | grok-4-0709 | grok-3 | grok-3-mini |
-
-#### OpenRouter
-
-| | | | |
-|---|---|---|---|
-| ai21/jamba-large-1.7 | aion-labs/aion-1.0 | aion-labs/aion-1.0-mini | aion-labs/aion-2.0 |
-| aion-labs/aion-rp-llama-3.1-8b | alfredpros/codellama-7b-instruct-solidity | allenai/olmo-3-32b-think | allenai/olmo-3.1-32b-instruct |
-| amazon/nova-2-lite-v1 | amazon/nova-lite-v1 | amazon/nova-micro-v1 | amazon/nova-premier-v1 |
-| amazon/nova-pro-v1 | ~anthropic/claude-haiku-latest | ~anthropic/claude-sonnet-latest | anthropic/claude-3-haiku |
-| anthropic/claude-3.5-haiku | anthropic/claude-3.7-sonnet | anthropic/claude-3.7-sonnet:thinking | anthropic/claude-haiku-4.5 |
-| anthropic/claude-opus-4 | anthropic/claude-opus-4.1 | anthropic/claude-opus-4.5 | anthropic/claude-opus-4.6 |
-| anthropic/claude-opus-4.6-fast | anthropic/claude-opus-4.7 | ~anthropic/claude-opus-latest | anthropic/claude-sonnet-4 |
-| anthropic/claude-sonnet-4.5 | anthropic/claude-sonnet-4.6 | arcee-ai/coder-large | arcee-ai/maestro-reasoning |
-| arcee-ai/spotlight | arcee-ai/trinity-large-preview | arcee-ai/trinity-large-thinking | arcee-ai/trinity-mini |
-| arcee-ai/virtuoso-large | openrouter/auto | baidu/ernie-4.5-21b-a3b | baidu/ernie-4.5-21b-a3b-thinking |
-| baidu/ernie-4.5-300b-a47b | baidu/ernie-4.5-vl-28b-a3b | baidu/ernie-4.5-vl-424b-a47b | baidu/qianfan-ocr-fast:free |
-| openrouter/bodybuilder | bytedance-seed/seed-1.6 | bytedance-seed/seed-1.6-flash | bytedance-seed/seed-2.0-lite |
-| bytedance-seed/seed-2.0-mini | bytedance/ui-tars-1.5-7b | cohere/command-a | cohere/command-r-08-2024 |
-| cohere/command-r-plus-08-2024 | cohere/command-r7b-12-2024 | deepcogito/cogito-v2.1-671b | deepseek/deepseek-chat |
-| deepseek/deepseek-chat-v3-0324 | deepseek/deepseek-chat-v3.1 | deepseek/deepseek-v3.1-terminus | deepseek/deepseek-v3.2 |
-| deepseek/deepseek-v3.2-exp | deepseek/deepseek-v3.2-speciale | deepseek/deepseek-v4-flash | deepseek/deepseek-v4-pro |
-| deepseek/deepseek-r1 | deepseek/deepseek-r1-0528 | deepseek/deepseek-r1-distill-llama-70b | deepseek/deepseek-r1-distill-qwen-32b |
-| essentialai/rnj-1-instruct | openrouter/free | alpindale/goliath-120b | ~google/gemini-flash-latest |
-| ~google/gemini-pro-latest | google/gemini-2.0-flash-001 | google/gemini-2.0-flash-lite-001 | google/gemini-2.5-flash |
-| google/gemini-2.5-flash-lite | google/gemini-2.5-flash-lite-preview-09-2025 | google/gemini-2.5-pro | google/gemini-2.5-pro-preview-05-06 |
-| google/gemini-2.5-pro-preview | google/gemini-3-flash-preview | google/gemini-3.1-flash-lite-preview | google/gemini-3.1-pro-preview |
-| google/gemini-3.1-pro-preview-customtools | google/gemma-2-27b-it | google/gemma-3-12b-it | google/gemma-3-12b-it:free |
-| google/gemma-3-27b-it | google/gemma-3-27b-it:free | google/gemma-3-4b-it | google/gemma-3-4b-it:free |
-| google/gemma-3n-e2b-it:free | google/gemma-3n-e4b-it | google/gemma-3n-e4b-it:free | google/gemma-4-26b-a4b-it |
-| google/gemma-4-26b-a4b-it:free | google/gemma-4-31b-it | google/gemma-4-31b-it:free | google/lyria-3-clip-preview |
-| google/lyria-3-pro-preview | google/gemini-2.5-flash-image | google/gemini-3.1-flash-image-preview | google/gemini-3-pro-image-preview |
-| ibm-granite/granite-4.0-h-micro | inception/mercury-2 | inclusionai/ling-2.6-1t:free | inclusionai/ling-2.6-flash |
-| inflection/inflection-3-pi | inflection/inflection-3-productivity | kwaipilot/kat-coder-pro-v2 | liquid/lfm-2-24b-a2b |
-| liquid/lfm-2.5-1.2b-instruct:free | liquid/lfm-2.5-1.2b-thinking:free | meta-llama/llama-guard-3-8b | anthracite-org/magnum-v4-72b |
-| mancer/weaver | meta-llama/llama-3-70b-instruct | meta-llama/llama-3-8b-instruct | meta-llama/llama-3.1-70b-instruct |
-| meta-llama/llama-3.1-8b-instruct | meta-llama/llama-3.2-11b-vision-instruct | meta-llama/llama-3.2-1b-instruct | meta-llama/llama-3.2-3b-instruct |
-| meta-llama/llama-3.2-3b-instruct:free | meta-llama/llama-3.3-70b-instruct | meta-llama/llama-3.3-70b-instruct:free | meta-llama/llama-4-maverick |
-| meta-llama/llama-4-scout | meta-llama/llama-guard-4-12b | microsoft/phi-4 | minimax/minimax-m1 |
-| minimax/minimax-m2 | minimax/minimax-m2-her | minimax/minimax-m2.1 | minimax/minimax-m2.5 |
-| minimax/minimax-m2.5:free | minimax/minimax-m2.7 | minimax/minimax-01 | mistralai/mistral-large |
-| mistralai/mistral-large-2407 | mistralai/mistral-large-2411 | mistralai/codestral-2508 | mistralai/devstral-2512 |
-| mistralai/devstral-medium | mistralai/devstral-small | mistralai/ministral-14b-2512 | mistralai/ministral-3b-2512 |
-| mistralai/ministral-8b-2512 | mistralai/mistral-7b-instruct-v0.1 | mistralai/mistral-large-2512 | mistralai/mistral-medium-3 |
-| mistralai/mistral-medium-3.1 | mistralai/mistral-nemo | mistralai/mistral-small-24b-instruct-2501 | mistralai/mistral-small-3.1-24b-instruct |
-| mistralai/mistral-small-3.2-24b-instruct | mistralai/mistral-small-2603 | mistralai/mistral-small-creative | mistralai/mixtral-8x22b-instruct |
-| mistralai/mixtral-8x7b-instruct | mistralai/pixtral-large-2411 | mistralai/mistral-saba | mistralai/voxtral-small-24b-2507 |
-| ~moonshotai/kimi-latest | moonshotai/kimi-k2 | moonshotai/kimi-k2-0905 | moonshotai/kimi-k2-thinking |
-| moonshotai/kimi-k2.5 | moonshotai/kimi-k2.6 | morph/morph-v3-fast | morph/morph-v3-large |
-| gryphe/mythomax-l2-13b | nex-agi/deepseek-v3.1-nex-n1 | nousresearch/hermes-3-llama-3.1-405b | nousresearch/hermes-3-llama-3.1-405b:free |
-| nousresearch/hermes-3-llama-3.1-70b | nousresearch/hermes-4-405b | nousresearch/hermes-4-70b | nousresearch/hermes-2-pro-llama-3-8b |
-| nvidia/llama-3.1-nemotron-70b-instruct | nvidia/llama-3.3-nemotron-super-49b-v1.5 | nvidia/nemotron-3-nano-30b-a3b | nvidia/nemotron-3-nano-30b-a3b:free |
-| nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free | nvidia/nemotron-3-super-120b-a12b | nvidia/nemotron-3-super-120b-a12b:free | nvidia/nemotron-nano-12b-v2-vl |
-| nvidia/nemotron-nano-12b-v2-vl:free | nvidia/nemotron-nano-9b-v2 | nvidia/nemotron-nano-9b-v2:free | ~openai/gpt-latest |
-| ~openai/gpt-mini-latest | openai/gpt-audio | openai/gpt-audio-mini | openai/gpt-3.5-turbo |
-| openai/gpt-3.5-turbo-0613 | openai/gpt-3.5-turbo-16k | openai/gpt-3.5-turbo-instruct | openai/gpt-4 |
-| openai/gpt-4-0314 | openai/gpt-4-turbo | openai/gpt-4-1106-preview | openai/gpt-4-turbo-preview |
-| openai/gpt-4.1 | openai/gpt-4.1-mini | openai/gpt-4.1-nano | openai/gpt-4o |
-| openai/gpt-4o-2024-05-13 | openai/gpt-4o-2024-08-06 | openai/gpt-4o-2024-11-20 | openai/gpt-4o-audio-preview |
-| openai/gpt-4o-search-preview | openai/gpt-4o-mini | openai/gpt-4o-mini-2024-07-18 | openai/gpt-4o-mini-search-preview |
-| openai/gpt-5 | openai/gpt-5-chat | openai/gpt-5-codex | openai/gpt-5-image |
-| openai/gpt-5-image-mini | openai/gpt-5-mini | openai/gpt-5-nano | openai/gpt-5-pro |
-| openai/gpt-5.1 | openai/gpt-5.1-chat | openai/gpt-5.1-codex | openai/gpt-5.1-codex-max |
-| openai/gpt-5.1-codex-mini | openai/gpt-5.2 | openai/gpt-5.2-chat | openai/gpt-5.2-pro |
-| openai/gpt-5.2-codex | openai/gpt-5.3-chat | openai/gpt-5.3-codex | openai/gpt-5.4 |
-| openai/gpt-5.4-image-2 | openai/gpt-5.4-mini | openai/gpt-5.4-nano | openai/gpt-5.4-pro |
-| openai/gpt-5.5 | openai/gpt-5.5-pro | openai/gpt-oss-120b | openai/gpt-oss-120b:free |
-| openai/gpt-oss-20b | openai/gpt-oss-20b:free | openai/gpt-oss-safeguard-20b | openai/o1 |
-| openai/o1-pro | openai/o3 | openai/o3-deep-research | openai/o3-mini |
-| openai/o3-mini-high | openai/o3-pro | openai/o4-mini | openai/o4-mini-deep-research |
-| openai/o4-mini-high | openrouter/pareto-code | perplexity/sonar | perplexity/sonar-deep-research |
-| perplexity/sonar-pro | perplexity/sonar-pro-search | perplexity/sonar-reasoning-pro | poolside/laguna-m.1:free |
-| poolside/laguna-xs.2:free | prime-intellect/intellect-3 | qwen/qwen-plus-2025-07-28 | qwen/qwen-plus-2025-07-28:thinking |
-| qwen/qwen-vl-max | qwen/qwen-vl-plus | qwen/qwen-max | qwen/qwen-plus |
-| qwen/qwen-turbo | qwen/qwen-2.5-7b-instruct | qwen/qwen2.5-vl-72b-instruct | qwen/qwen3-14b |
-| qwen/qwen3-235b-a22b | qwen/qwen3-235b-a22b-2507 | qwen/qwen3-235b-a22b-thinking-2507 | qwen/qwen3-30b-a3b |
-| qwen/qwen3-30b-a3b-instruct-2507 | qwen/qwen3-30b-a3b-thinking-2507 | qwen/qwen3-32b | qwen/qwen3-8b |
-| qwen/qwen3-coder-30b-a3b-instruct | qwen/qwen3-coder | qwen/qwen3-coder:free | qwen/qwen3-coder-flash |
-| qwen/qwen3-coder-next | qwen/qwen3-coder-plus | qwen/qwen3-max | qwen/qwen3-max-thinking |
-| qwen/qwen3-next-80b-a3b-instruct | qwen/qwen3-next-80b-a3b-instruct:free | qwen/qwen3-next-80b-a3b-thinking | qwen/qwen3-vl-235b-a22b-instruct |
-| qwen/qwen3-vl-235b-a22b-thinking | qwen/qwen3-vl-30b-a3b-instruct | qwen/qwen3-vl-30b-a3b-thinking | qwen/qwen3-vl-32b-instruct |
-| qwen/qwen3-vl-8b-instruct | qwen/qwen3-vl-8b-thinking | qwen/qwen3.5-397b-a17b | qwen/qwen3.5-plus-02-15 |
-| qwen/qwen3.5-plus-20260420 | qwen/qwen3.5-122b-a10b | qwen/qwen3.5-27b | qwen/qwen3.5-35b-a3b |
-| qwen/qwen3.5-9b | qwen/qwen3.5-flash-02-23 | qwen/qwen3.6-27b | qwen/qwen3.6-35b-a3b |
-| qwen/qwen3.6-flash | qwen/qwen3.6-max-preview | qwen/qwen3.6-plus | qwen/qwen-2.5-72b-instruct |
-| qwen/qwen-2.5-coder-32b-instruct | rekaai/reka-edge | rekaai/reka-flash-3 | relace/relace-apply-3 |
-| relace/relace-search | undi95/remm-slerp-l2-13b | sao10k/l3-lunaris-8b | sao10k/l3-euryale-70b |
-| sao10k/l3.1-70b-hanami-x1 | sao10k/l3.1-euryale-70b | sao10k/l3.3-euryale-70b | stepfun/step-3.5-flash |
-| switchpoint/router | tencent/hunyuan-a13b-instruct | tencent/hy3-preview:free | thedrummer/cydonia-24b-v4.1 |
-| thedrummer/rocinante-12b | thedrummer/skyfall-36b-v2 | thedrummer/unslopnemo-12b | tngtech/deepseek-r1t2-chimera |
-| alibaba/tongyi-deepresearch-30b-a3b | upstage/solar-pro-3 | cognitivecomputations/dolphin-mistral-24b-venice-edition:free | microsoft/wizardlm-2-8x22b |
-| writer/palmyra-x5 | x-ai/grok-3 | x-ai/grok-3-beta | x-ai/grok-3-mini |
-| x-ai/grok-3-mini-beta | x-ai/grok-4 | x-ai/grok-4-fast | x-ai/grok-4.1-fast |
-| x-ai/grok-4.20 | x-ai/grok-4.20-multi-agent | x-ai/grok-code-fast-1 | xiaomi/mimo-v2-flash |
-| xiaomi/mimo-v2-omni | xiaomi/mimo-v2-pro | xiaomi/mimo-v2.5 | xiaomi/mimo-v2.5-pro |
-| z-ai/glm-4-32b | z-ai/glm-4.5 | z-ai/glm-4.5-air | z-ai/glm-4.5-air:free |
-| z-ai/glm-4.5v | z-ai/glm-4.6 | z-ai/glm-4.6v | z-ai/glm-4.7 |
-| z-ai/glm-4.7-flash | z-ai/glm-5 | z-ai/glm-5-turbo | z-ai/glm-5.1 |
-| z-ai/glm-5v-turbo | | | |
-
-<!-- END_MODEL_TABLE -->
-
-</details>
-
 ![image](https://github.com/dxpr/ckeditor5-ai-agent/blob/1.x/sample/images/toolbar-switching.gif)
 Video of AI Agent returning optimal HTML structure based on what is available in the toolbar, when a user prompt is "incorrect". After switching the editor configuration from "Full HTML" to "Basic HTML," an unordered list is generated instead of a table, using bold and normal-weight text to simulate some table-like structure.
 
 ## Table of Contents
 
-- [Supported Models](#supported-models)
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [How to Use](#how-to-use)
@@ -585,3 +397,185 @@ yarn start
 # Serve DLL sample
 yarn dll:serve
 ```
+
+## Supported Models
+
+<!-- BEGIN_MODEL_TABLE -->
+
+#### DXAI
+
+| | | | |
+|---|---|---|---|
+| kavya-m1 | kavya-m1-eu | | |
+
+#### Google
+
+| | | | |
+|---|---|---|---|
+| lyria-3-pro-preview | lyria-3-clip-preview | gemma-4-31b-it | gemma-4-26b-a4b-it |
+| gemma-3n-e4b-it | gemma-3n-e2b-it | gemma-3-4b-it | gemma-3-27b-it |
+| gemma-3-1b-it | gemma-3-12b-it | gemini-robotics-er-1.6-preview | gemini-robotics-er-1.5-preview |
+| gemini-pro-latest | gemini-flash-lite-latest | gemini-flash-latest | gemini-3.1-pro-preview-customtools |
+| gemini-3.1-pro-preview | gemini-3.1-flash-tts-preview | gemini-3.1-flash-lite-preview | gemini-3-pro-preview |
+| gemini-3-flash-preview | gemini-2.5-pro | gemini-2.5-flash-lite | gemini-2.5-flash |
+| gemini-2.0-flash-lite-001 | gemini-2.0-flash-lite | gemini-2.0-flash-001 | gemini-2.0-flash |
+| deep-research-pro-preview-12-2025 | deep-research-preview-04-2026 | deep-research-max-preview-04-2026 | |
+
+#### OpenAI
+
+| | | | |
+|---|---|---|---|
+| gpt-5.5-pro-2026-04-23 | gpt-5.5-pro | gpt-5.5-2026-04-23 | gpt-5.5 |
+| gpt-5.4-mini | gpt-5.4-mini-2026-03-17 | gpt-5.4-nano | gpt-5.4-nano-2026-03-17 |
+| gpt-5.4 | gpt-5.4-pro-2026-03-05 | gpt-5.4-pro | gpt-5.4-2026-03-05 |
+| gpt-5.3-chat-latest | gpt-5.3-codex | gpt-5.2-codex | gpt-5.2-chat-latest |
+| gpt-5.2-pro | gpt-5.2-pro-2025-12-11 | gpt-5.2 | gpt-5.2-2025-12-11 |
+| gpt-5.1-codex-max | gpt-5.1-codex-mini | gpt-5.1-codex | gpt-5.1 |
+| gpt-5.1-2025-11-13 | gpt-5.1-chat-latest | gpt-5-pro | gpt-5-pro-2025-10-06 |
+| gpt-5-codex | gpt-5-nano | gpt-5-nano-2025-08-07 | gpt-5-mini |
+| gpt-5-mini-2025-08-07 | gpt-5 | gpt-5-2025-08-07 | gpt-5-chat-latest |
+| o3-pro-2025-06-10 | o3-pro | gpt-4.1-nano | gpt-4.1-nano-2025-04-14 |
+| gpt-4.1-mini | gpt-4.1-mini-2025-04-14 | gpt-4.1 | gpt-4.1-2025-04-14 |
+| o4-mini | o3 | o4-mini-2025-04-16 | o3-2025-04-16 |
+| o1-pro | o1-pro-2025-03-19 | gpt-4o-2024-11-20 | o3-mini-2025-01-31 |
+| o3-mini | o1 | o1-2024-12-17 | gpt-4o-2024-08-06 |
+| gpt-4o-mini | gpt-4o-mini-2024-07-18 | gpt-4o-2024-05-13 | gpt-4o |
+| gpt-4-turbo-2024-04-09 | gpt-4-turbo | gpt-3.5-turbo-0125 | gpt-3.5-turbo-1106 |
+| gpt-3.5-turbo-instruct-0914 | gpt-3.5-turbo-instruct | gpt-4 | gpt-4-0613 |
+| gpt-3.5-turbo-16k | gpt-3.5-turbo | | |
+
+#### Anthropic
+
+| | | | |
+|---|---|---|---|
+| claude-opus-4-7 | claude-sonnet-4-6 | claude-opus-4-6 | claude-opus-4-5-20251101 |
+| claude-haiku-4-5-20251001 | claude-sonnet-4-5-20250929 | claude-opus-4-1-20250805 | claude-opus-4-20250514 |
+| claude-sonnet-4-20250514 | | | |
+
+#### Mistral AI
+
+| | | | |
+|---|---|---|---|
+| codestral-latest | devstral-2512 | devstral-medium-latest | devstral-latest |
+| devstral-medium-2507 | devstral-small-2507 | labs-leanstral-2603 | labs-mistral-small-creative |
+| magistral-medium-latest | magistral-small-latest | ministral-14b-latest | ministral-3b-latest |
+| ministral-8b-latest | mistral-large-2411 | mistral-large-2512 | mistral-large-latest |
+| mistral-medium-2505 | mistral-medium-latest | mistral-small-2506 | mistral-small-latest |
+| mistral-tiny-latest | mistral-vibe-cli-latest | pixtral-large-latest | voxtral-mini-latest |
+| voxtral-small-latest | | | |
+
+#### Groq
+
+| | | | |
+|---|---|---|---|
+| canopylabs/orpheus-v1-english | canopylabs/orpheus-arabic-saudi | groq/compound-mini | groq/compound |
+| openai/gpt-oss-120b | openai/gpt-oss-20b | qwen/qwen3-32b | meta-llama/llama-4-scout-17b-16e-instruct |
+| allam-2-7b | llama-3.3-70b-versatile | llama-3.1-8b-instant | |
+
+#### xAI
+
+| | | | |
+|---|---|---|---|
+| grok-4.20-0309-non-reasoning | grok-4.20-0309-reasoning | grok-4.20-multi-agent-0309 | grok-imagine-video |
+| grok-4-1-fast-non-reasoning | grok-4-1-fast-reasoning | grok-4-fast-non-reasoning | grok-4-fast-reasoning |
+| grok-code-fast-1 | grok-4-0709 | grok-3 | grok-3-mini |
+
+#### OpenRouter
+
+| | | | |
+|---|---|---|---|
+| ai21/jamba-large-1.7 | aion-labs/aion-1.0 | aion-labs/aion-1.0-mini | aion-labs/aion-2.0 |
+| aion-labs/aion-rp-llama-3.1-8b | alfredpros/codellama-7b-instruct-solidity | allenai/olmo-3-32b-think | allenai/olmo-3.1-32b-instruct |
+| amazon/nova-2-lite-v1 | amazon/nova-lite-v1 | amazon/nova-micro-v1 | amazon/nova-premier-v1 |
+| amazon/nova-pro-v1 | ~anthropic/claude-haiku-latest | ~anthropic/claude-sonnet-latest | anthropic/claude-3-haiku |
+| anthropic/claude-3.5-haiku | anthropic/claude-3.7-sonnet | anthropic/claude-3.7-sonnet:thinking | anthropic/claude-haiku-4.5 |
+| anthropic/claude-opus-4 | anthropic/claude-opus-4.1 | anthropic/claude-opus-4.5 | anthropic/claude-opus-4.6 |
+| anthropic/claude-opus-4.6-fast | anthropic/claude-opus-4.7 | ~anthropic/claude-opus-latest | anthropic/claude-sonnet-4 |
+| anthropic/claude-sonnet-4.5 | anthropic/claude-sonnet-4.6 | arcee-ai/coder-large | arcee-ai/maestro-reasoning |
+| arcee-ai/spotlight | arcee-ai/trinity-large-preview | arcee-ai/trinity-large-thinking | arcee-ai/trinity-mini |
+| arcee-ai/virtuoso-large | openrouter/auto | baidu/ernie-4.5-21b-a3b | baidu/ernie-4.5-21b-a3b-thinking |
+| baidu/ernie-4.5-300b-a47b | baidu/ernie-4.5-vl-28b-a3b | baidu/ernie-4.5-vl-424b-a47b | baidu/qianfan-ocr-fast:free |
+| openrouter/bodybuilder | bytedance-seed/seed-1.6 | bytedance-seed/seed-1.6-flash | bytedance-seed/seed-2.0-lite |
+| bytedance-seed/seed-2.0-mini | bytedance/ui-tars-1.5-7b | cohere/command-a | cohere/command-r-08-2024 |
+| cohere/command-r-plus-08-2024 | cohere/command-r7b-12-2024 | deepcogito/cogito-v2.1-671b | deepseek/deepseek-chat |
+| deepseek/deepseek-chat-v3-0324 | deepseek/deepseek-chat-v3.1 | deepseek/deepseek-v3.1-terminus | deepseek/deepseek-v3.2 |
+| deepseek/deepseek-v3.2-exp | deepseek/deepseek-v3.2-speciale | deepseek/deepseek-v4-flash | deepseek/deepseek-v4-pro |
+| deepseek/deepseek-r1 | deepseek/deepseek-r1-0528 | deepseek/deepseek-r1-distill-llama-70b | deepseek/deepseek-r1-distill-qwen-32b |
+| essentialai/rnj-1-instruct | openrouter/free | alpindale/goliath-120b | ~google/gemini-flash-latest |
+| ~google/gemini-pro-latest | google/gemini-2.0-flash-001 | google/gemini-2.0-flash-lite-001 | google/gemini-2.5-flash |
+| google/gemini-2.5-flash-lite | google/gemini-2.5-flash-lite-preview-09-2025 | google/gemini-2.5-pro | google/gemini-2.5-pro-preview-05-06 |
+| google/gemini-2.5-pro-preview | google/gemini-3-flash-preview | google/gemini-3.1-flash-lite-preview | google/gemini-3.1-pro-preview |
+| google/gemini-3.1-pro-preview-customtools | google/gemma-2-27b-it | google/gemma-3-12b-it | google/gemma-3-12b-it:free |
+| google/gemma-3-27b-it | google/gemma-3-27b-it:free | google/gemma-3-4b-it | google/gemma-3-4b-it:free |
+| google/gemma-3n-e2b-it:free | google/gemma-3n-e4b-it | google/gemma-3n-e4b-it:free | google/gemma-4-26b-a4b-it |
+| google/gemma-4-26b-a4b-it:free | google/gemma-4-31b-it | google/gemma-4-31b-it:free | google/lyria-3-clip-preview |
+| google/lyria-3-pro-preview | google/gemini-2.5-flash-image | google/gemini-3.1-flash-image-preview | google/gemini-3-pro-image-preview |
+| ibm-granite/granite-4.0-h-micro | inception/mercury-2 | inclusionai/ling-2.6-1t:free | inclusionai/ling-2.6-flash |
+| inflection/inflection-3-pi | inflection/inflection-3-productivity | kwaipilot/kat-coder-pro-v2 | liquid/lfm-2-24b-a2b |
+| liquid/lfm-2.5-1.2b-instruct:free | liquid/lfm-2.5-1.2b-thinking:free | meta-llama/llama-guard-3-8b | anthracite-org/magnum-v4-72b |
+| mancer/weaver | meta-llama/llama-3-70b-instruct | meta-llama/llama-3-8b-instruct | meta-llama/llama-3.1-70b-instruct |
+| meta-llama/llama-3.1-8b-instruct | meta-llama/llama-3.2-11b-vision-instruct | meta-llama/llama-3.2-1b-instruct | meta-llama/llama-3.2-3b-instruct |
+| meta-llama/llama-3.2-3b-instruct:free | meta-llama/llama-3.3-70b-instruct | meta-llama/llama-3.3-70b-instruct:free | meta-llama/llama-4-maverick |
+| meta-llama/llama-4-scout | meta-llama/llama-guard-4-12b | microsoft/phi-4 | minimax/minimax-m1 |
+| minimax/minimax-m2 | minimax/minimax-m2-her | minimax/minimax-m2.1 | minimax/minimax-m2.5 |
+| minimax/minimax-m2.5:free | minimax/minimax-m2.7 | minimax/minimax-01 | mistralai/mistral-large |
+| mistralai/mistral-large-2407 | mistralai/mistral-large-2411 | mistralai/codestral-2508 | mistralai/devstral-2512 |
+| mistralai/devstral-medium | mistralai/devstral-small | mistralai/ministral-14b-2512 | mistralai/ministral-3b-2512 |
+| mistralai/ministral-8b-2512 | mistralai/mistral-7b-instruct-v0.1 | mistralai/mistral-large-2512 | mistralai/mistral-medium-3 |
+| mistralai/mistral-medium-3.1 | mistralai/mistral-nemo | mistralai/mistral-small-24b-instruct-2501 | mistralai/mistral-small-3.1-24b-instruct |
+| mistralai/mistral-small-3.2-24b-instruct | mistralai/mistral-small-2603 | mistralai/mistral-small-creative | mistralai/mixtral-8x22b-instruct |
+| mistralai/mixtral-8x7b-instruct | mistralai/pixtral-large-2411 | mistralai/mistral-saba | mistralai/voxtral-small-24b-2507 |
+| ~moonshotai/kimi-latest | moonshotai/kimi-k2 | moonshotai/kimi-k2-0905 | moonshotai/kimi-k2-thinking |
+| moonshotai/kimi-k2.5 | moonshotai/kimi-k2.6 | morph/morph-v3-fast | morph/morph-v3-large |
+| gryphe/mythomax-l2-13b | nex-agi/deepseek-v3.1-nex-n1 | nousresearch/hermes-3-llama-3.1-405b | nousresearch/hermes-3-llama-3.1-405b:free |
+| nousresearch/hermes-3-llama-3.1-70b | nousresearch/hermes-4-405b | nousresearch/hermes-4-70b | nousresearch/hermes-2-pro-llama-3-8b |
+| nvidia/llama-3.1-nemotron-70b-instruct | nvidia/llama-3.3-nemotron-super-49b-v1.5 | nvidia/nemotron-3-nano-30b-a3b | nvidia/nemotron-3-nano-30b-a3b:free |
+| nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free | nvidia/nemotron-3-super-120b-a12b | nvidia/nemotron-3-super-120b-a12b:free | nvidia/nemotron-nano-12b-v2-vl |
+| nvidia/nemotron-nano-12b-v2-vl:free | nvidia/nemotron-nano-9b-v2 | nvidia/nemotron-nano-9b-v2:free | ~openai/gpt-latest |
+| ~openai/gpt-mini-latest | openai/gpt-audio | openai/gpt-audio-mini | openai/gpt-3.5-turbo |
+| openai/gpt-3.5-turbo-0613 | openai/gpt-3.5-turbo-16k | openai/gpt-3.5-turbo-instruct | openai/gpt-4 |
+| openai/gpt-4-0314 | openai/gpt-4-turbo | openai/gpt-4-1106-preview | openai/gpt-4-turbo-preview |
+| openai/gpt-4.1 | openai/gpt-4.1-mini | openai/gpt-4.1-nano | openai/gpt-4o |
+| openai/gpt-4o-2024-05-13 | openai/gpt-4o-2024-08-06 | openai/gpt-4o-2024-11-20 | openai/gpt-4o-audio-preview |
+| openai/gpt-4o-search-preview | openai/gpt-4o-mini | openai/gpt-4o-mini-2024-07-18 | openai/gpt-4o-mini-search-preview |
+| openai/gpt-5 | openai/gpt-5-chat | openai/gpt-5-codex | openai/gpt-5-image |
+| openai/gpt-5-image-mini | openai/gpt-5-mini | openai/gpt-5-nano | openai/gpt-5-pro |
+| openai/gpt-5.1 | openai/gpt-5.1-chat | openai/gpt-5.1-codex | openai/gpt-5.1-codex-max |
+| openai/gpt-5.1-codex-mini | openai/gpt-5.2 | openai/gpt-5.2-chat | openai/gpt-5.2-pro |
+| openai/gpt-5.2-codex | openai/gpt-5.3-chat | openai/gpt-5.3-codex | openai/gpt-5.4 |
+| openai/gpt-5.4-image-2 | openai/gpt-5.4-mini | openai/gpt-5.4-nano | openai/gpt-5.4-pro |
+| openai/gpt-5.5 | openai/gpt-5.5-pro | openai/gpt-oss-120b | openai/gpt-oss-120b:free |
+| openai/gpt-oss-20b | openai/gpt-oss-20b:free | openai/gpt-oss-safeguard-20b | openai/o1 |
+| openai/o1-pro | openai/o3 | openai/o3-deep-research | openai/o3-mini |
+| openai/o3-mini-high | openai/o3-pro | openai/o4-mini | openai/o4-mini-deep-research |
+| openai/o4-mini-high | openrouter/pareto-code | perplexity/sonar | perplexity/sonar-deep-research |
+| perplexity/sonar-pro | perplexity/sonar-pro-search | perplexity/sonar-reasoning-pro | poolside/laguna-m.1:free |
+| poolside/laguna-xs.2:free | prime-intellect/intellect-3 | qwen/qwen-plus-2025-07-28 | qwen/qwen-plus-2025-07-28:thinking |
+| qwen/qwen-vl-max | qwen/qwen-vl-plus | qwen/qwen-max | qwen/qwen-plus |
+| qwen/qwen-turbo | qwen/qwen-2.5-7b-instruct | qwen/qwen2.5-vl-72b-instruct | qwen/qwen3-14b |
+| qwen/qwen3-235b-a22b | qwen/qwen3-235b-a22b-2507 | qwen/qwen3-235b-a22b-thinking-2507 | qwen/qwen3-30b-a3b |
+| qwen/qwen3-30b-a3b-instruct-2507 | qwen/qwen3-30b-a3b-thinking-2507 | qwen/qwen3-32b | qwen/qwen3-8b |
+| qwen/qwen3-coder-30b-a3b-instruct | qwen/qwen3-coder | qwen/qwen3-coder:free | qwen/qwen3-coder-flash |
+| qwen/qwen3-coder-next | qwen/qwen3-coder-plus | qwen/qwen3-max | qwen/qwen3-max-thinking |
+| qwen/qwen3-next-80b-a3b-instruct | qwen/qwen3-next-80b-a3b-instruct:free | qwen/qwen3-next-80b-a3b-thinking | qwen/qwen3-vl-235b-a22b-instruct |
+| qwen/qwen3-vl-235b-a22b-thinking | qwen/qwen3-vl-30b-a3b-instruct | qwen/qwen3-vl-30b-a3b-thinking | qwen/qwen3-vl-32b-instruct |
+| qwen/qwen3-vl-8b-instruct | qwen/qwen3-vl-8b-thinking | qwen/qwen3.5-397b-a17b | qwen/qwen3.5-plus-02-15 |
+| qwen/qwen3.5-plus-20260420 | qwen/qwen3.5-122b-a10b | qwen/qwen3.5-27b | qwen/qwen3.5-35b-a3b |
+| qwen/qwen3.5-9b | qwen/qwen3.5-flash-02-23 | qwen/qwen3.6-27b | qwen/qwen3.6-35b-a3b |
+| qwen/qwen3.6-flash | qwen/qwen3.6-max-preview | qwen/qwen3.6-plus | qwen/qwen-2.5-72b-instruct |
+| qwen/qwen-2.5-coder-32b-instruct | rekaai/reka-edge | rekaai/reka-flash-3 | relace/relace-apply-3 |
+| relace/relace-search | undi95/remm-slerp-l2-13b | sao10k/l3-lunaris-8b | sao10k/l3-euryale-70b |
+| sao10k/l3.1-70b-hanami-x1 | sao10k/l3.1-euryale-70b | sao10k/l3.3-euryale-70b | stepfun/step-3.5-flash |
+| switchpoint/router | tencent/hunyuan-a13b-instruct | tencent/hy3-preview:free | thedrummer/cydonia-24b-v4.1 |
+| thedrummer/rocinante-12b | thedrummer/skyfall-36b-v2 | thedrummer/unslopnemo-12b | tngtech/deepseek-r1t2-chimera |
+| alibaba/tongyi-deepresearch-30b-a3b | upstage/solar-pro-3 | cognitivecomputations/dolphin-mistral-24b-venice-edition:free | microsoft/wizardlm-2-8x22b |
+| writer/palmyra-x5 | x-ai/grok-3 | x-ai/grok-3-beta | x-ai/grok-3-mini |
+| x-ai/grok-3-mini-beta | x-ai/grok-4 | x-ai/grok-4-fast | x-ai/grok-4.1-fast |
+| x-ai/grok-4.20 | x-ai/grok-4.20-multi-agent | x-ai/grok-code-fast-1 | xiaomi/mimo-v2-flash |
+| xiaomi/mimo-v2-omni | xiaomi/mimo-v2-pro | xiaomi/mimo-v2.5 | xiaomi/mimo-v2.5-pro |
+| z-ai/glm-4-32b | z-ai/glm-4.5 | z-ai/glm-4.5-air | z-ai/glm-4.5-air:free |
+| z-ai/glm-4.5v | z-ai/glm-4.6 | z-ai/glm-4.6v | z-ai/glm-4.7 |
+| z-ai/glm-4.7-flash | z-ai/glm-5 | z-ai/glm-5-turbo | z-ai/glm-5.1 |
+| z-ai/glm-5v-turbo | | | |
+
+<!-- END_MODEL_TABLE -->


### PR DESCRIPTION
## Summary

- Adds a collapsible "Supported Models" section to README.md with a 4-column table listing all 529 models grouped by provider (DXAI, Google, OpenAI, Anthropic, Mistral AI, Groq, xAI, OpenRouter)
- Updates the `update-models` GitHub Action to auto-regenerate the table between `<!-- BEGIN_MODEL_TABLE -->` / `<!-- END_MODEL_TABLE -->` markers whenever the model list changes
- Adds "Supported Models" to the Table of Contents

## Test plan

- [ ] Verify the table renders correctly on GitHub (expand the `<details>` block)
- [ ] Confirm the daily `update-models` workflow still passes and updates both the count and the table
- [ ] Check that the model count and table content match `SUPPORTED_MODELS.json`