### PR TITLE
refactor: rename XML prompt tags to match dxpr_builder

### DIFF
--- a/src/util/prompt.ts
+++ b/src/util/prompt.ts
@@ -357,9 +357,9 @@ export class PromptHelper {
 
 		// Context-Specific Instructions
 		if ( !isEditorEmpty && !selectedContent ) {
-			corpus.push( '\n<CONTEXT_REQUIREMENTS>' );
+			corpus.push( '\n<GENERATION_CONSTRAINTS>' );
 			corpus.push( this.getComponentContent( 'contextRequirements' ) );
-			corpus.push( '</CONTEXT_REQUIREMENTS>' );
+			corpus.push( '</GENERATION_CONSTRAINTS>' );
 		}
 
 		// Add language instructions back

--- a/src/util/translations.ts
+++ b/src/util/translations.ts
@@ -101,7 +101,7 @@ export function getDefaultAiAgentDropdownMenu(
 				{
 					title: t( 'Improve Tone of Voice' ),
 					command:
-						`Rewrite the content to match the TONE while preserving the key message and meaning.
+						`Rewrite the content to match the PAGE_TONE while preserving the key message and meaning.
 						Ensure the writing style is consistent.\nYou must keep the text formatting.`
 				},
 				{


### PR DESCRIPTION
Update tag construction and prompt text references for renamed prompt tags.

## Linked issues

- Coordinated with dxpr/dxpr_builder#4680
- dxpr_builder PR: dxpr/dxpr_builder#4679
- kavya PR: dxpr/Kavya#188

## Changes

| Old tag | New tag |
|---------|---------|
| `<CONTEXT_REQUIREMENTS>` | `<GENERATION_CONSTRAINTS>` |
| `TONE` (in prompt text) | `PAGE_TONE` |

**Files changed:**
- `src/util/prompt.ts`: tag construction
- `src/util/translations.ts`: prompt text reference

**Must be merged together with:**
- dxpr/dxpr_builder#4679
- dxpr/Kavya#188