### PR TITLE
feat: use taxonomy term ID as tone storage key for multilingual support

### DIFF
--- a/src/aiagenttonecommand.ts
+++ b/src/aiagenttonecommand.ts
@@ -3,7 +3,7 @@ import { STORAGE_PREFIX } from './const.js';
 import { getDefaultAiAgentToneDropdownMenu } from './util/translations.js';
 export default class AiAgentToneCommand extends Command {
 	private readonly STORAGE_KEY = 'tone';
-	private availableTones: Array<{ label: string; key: string; tone: string }> = [];
+	private availableTones: Array<{ label: string; key: string; tone: string; tid?: number }> = [];
 	private debugMode: boolean = false;
 
 	/**
@@ -18,8 +18,9 @@ export default class AiAgentToneCommand extends Command {
 		const defaultTones = getDefaultAiAgentToneDropdownMenu( editor );
 		const configTonesDropdown = config?.tonesDropdown?.map( item => ( {
 			label: item.label,
-			key: item.label.toLowerCase().replace( / /g, '_' ),
-			tone: item.tone
+			key: item.tid ? String( item.tid ) : item.label.toLowerCase().replace( / /g, '_' ),
+			tone: item.tone,
+			tid: item.tid
 		} ) );
 		this.availableTones = configTonesDropdown ?
 			[ defaultTones[ 0 ], ...configTonesDropdown ] :

--- a/src/aiagenttonecommand.ts
+++ b/src/aiagenttonecommand.ts
@@ -37,16 +37,10 @@ export default class AiAgentToneCommand extends Command {
 	 *
 	 * @param options - An object containing the tone value to set.
 	 */
-	public override async execute( { value }: { value: string } ): Promise<void> {
-		// Set the value directly, replacing any previous tone
+	public override async execute( { value, key }: { value: string; key: string } ): Promise<void> {
 		this.value = value;
 		this.fire( 'change:value', { value } );
-
-		// Find the label for the selected tone value and persist it to localStorage
-		const selectedTone = this.availableTones.find( item => item.tone === value );
-		if ( selectedTone ) {
-			this.saveToneSelection( selectedTone.key );
-		}
+		this.saveToneSelection( key );
 	}
 
 	private saveToneSelection( toneKey: string ): void {

--- a/src/type-identifiers.ts
+++ b/src/type-identifiers.ts
@@ -88,6 +88,7 @@ export interface AiAgentConfig {
     tonesDropdown?: Array<{
         label: string;
         tone: string;
+        tid?: number;
     }>;
     contentScope?: string;
     writesPerSecond?: WritesPerSecond;

--- a/src/util/ai-agent-tone-button.ts
+++ b/src/util/ai-agent-tone-button.ts
@@ -19,8 +19,9 @@ export function addAiAgentToneButton( editor: Editor ): void {
 	const defaultTones = getDefaultAiAgentToneDropdownMenu( editor );
 	const configTonesDropdown = config?.tonesDropdown?.map( item => ( {
 		label: item.label,
-		key: item.label.toLowerCase().replace( / /g, '_' ),
-		tone: item.tone
+		key: item.tid ? String( item.tid ) : item.label.toLowerCase().replace( / /g, '_' ),
+		tone: item.tone,
+		tid: item.tid
 	} ) );
 
 	const tonesDropdown = configTonesDropdown ?

--- a/src/util/ai-agent-tone-button.ts
+++ b/src/util/ai-agent-tone-button.ts
@@ -40,7 +40,7 @@ export function addAiAgentToneButton( editor: Editor ): void {
 
 		const menuView = new MenuBarMenuView( locale );
 		const listView = new MenuBarMenuListView( locale );
-		const toneItems: Array<{ tone: string; checkIcon: IconView }> = [];
+		const toneItems: Array<{ key: string; checkIcon: IconView }> = [];
 
 		// Add group title for Tone
 		const titleView = new MenuBarMenuListItemView( locale, menuView );
@@ -62,7 +62,7 @@ export function addAiAgentToneButton( editor: Editor ): void {
 			} );
 
 			checkIconView.isVisible = false;
-			toneItems.push( { tone: item.tone, checkIcon: checkIconView } );
+			toneItems.push( { key: item.key, checkIcon: checkIconView } );
 
 			const spanView = new View( locale );
 			spanView.setTemplate( {
@@ -89,7 +89,8 @@ export function addAiAgentToneButton( editor: Editor ): void {
 				} );
 				checkIconView.isVisible = true;
 				editor.execute( 'aiAgentTone', {
-					value: item.tone
+					value: item.tone,
+					key: item.key
 				} );
 				editor.editing.view.focus();
 			} );
@@ -101,11 +102,9 @@ export function addAiAgentToneButton( editor: Editor ): void {
 		dropdownView.on( 'change:isOpen', () => {
 			if ( dropdownView.isOpen ) {
 				const storedToneKey = localStorage.getItem( `${ STORAGE_PREFIX }:tone` );
-				const matchingTone = tonesDropdown.find( item => item.key === storedToneKey );
-				const currentToneValue = matchingTone?.tone || '';
 
 				toneItems.forEach( item => {
-					item.checkIcon.isVisible = item.tone === currentToneValue;
+					item.checkIcon.isVisible = item.key === storedToneKey;
 				} );
 			}
 		} );

--- a/src/util/prompt.ts
+++ b/src/util/prompt.ts
@@ -148,8 +148,9 @@ export class PromptHelper {
 		const defaultTones = getDefaultAiAgentToneDropdownMenu( this.editor );
 		const configTonesDropdown = config?.tonesDropdown?.map( item => ( {
 			label: item.label,
-			key: item.label.toLowerCase().replace( / /g, '_' ),
-			tone: item.tone
+			key: item.tid ? String( item.tid ) : item.label.toLowerCase().replace( / /g, '_' ),
+			tone: item.tone,
+			tid: item.tid
 		} ) );
 		const availableTones = configTonesDropdown ?
 			[ defaultTones[ 0 ], ...configTonesDropdown ] :


### PR DESCRIPTION
## Summary

- When the backend sends a `tid` (taxonomy term ID) in tone dropdown items, use it as the localStorage key instead of deriving a key from the label text
- This makes tone selection stable across content languages: switching from English to Spanish content keeps the same tone selected, because the tid is language-independent
- Falls back to the existing label-derived key when `tid` is absent, so older backends continue to work

## Context

Both `dxpr_builder` and `ckeditor_ai_agent` Drupal modules now send `tid` in their tone dropdown configuration (see dxpr/dxpr_builder#4846 and dxpr/ckeditor_ai_agent#51). Previously, the stored key was derived from the English label (e.g. `professional`), which broke when the same tone appeared as `profesional` in Spanish or a different label in another language.

## Changes

- `src/type-identifiers.ts`: Add optional `tid` field to `tonesDropdown` item type
- `src/aiagenttonecommand.ts`: Use `String(tid)` as key when available
- `src/util/ai-agent-tone-button.ts`: Same
- `src/util/prompt.ts`: Same

## Migration

No migration needed. On first load after update, any previously stored label-based key simply won't match a tid-based key, so the tone resets to the default. The user re-selects their tone once, and from then on it persists correctly across languages.

## Test plan

- [ ] Verify tone selection works when backend sends `tid` in tone items
- [ ] Verify tone selection still works when backend does NOT send `tid` (label fallback)
- [ ] Verify switching content language preserves the selected tone
- [ ] Verify default tones (hardcoded, no tid) continue to work